### PR TITLE
Updates android-browser-helper and enables WebView fallback on config

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -42,6 +42,8 @@ const DEFAULT_SIGNING_KEY_ALIAS = 'android';
 const DEFAULT_ENABLE_NOTIFICATIONS = false;
 const DEFAULT_GENERATOR_APP_NAME = 'unknown';
 
+export type FallbackType = 'customtabs' | 'webview';
+
 /**
  * A wrapper around the WebManifest's ShortcutInfo.
  */
@@ -100,6 +102,7 @@ export class TwaManifest {
   shortcuts: ShortcutInfo[];
   generatorApp: string;
   webManifestUrl?: URL;
+  fallbackType: FallbackType;
 
   private static log: Log = new Log('twa-manifest');
 
@@ -122,6 +125,7 @@ export class TwaManifest {
     this.shortcuts = data.shortcuts;
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
+    this.fallbackType = data.fallbackType || 'customtabs';
   }
 
   /**
@@ -290,6 +294,7 @@ export interface TwaManifestJson {
   shortcuts: ShortcutInfo[];
   generatorApp?: string;
   webManifestUrl?: string;
+  fallbackType?: FallbackType;
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -134,6 +134,7 @@ describe('TwaManifest', () => {
         shortcuts: [{name: 'name', shortName: 'shortName', url: '/', chosenIconUrl: 'icon.png'}],
         webManifestUrl: 'https://pwa-directory.com/manifest.json',
         generatorApp: 'test',
+        fallbackType: 'webview',
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
@@ -155,9 +156,10 @@ describe('TwaManifest', () => {
       expect(twaManifest.shortcuts).toEqual(twaManifestJson.shortcuts);
       expect(twaManifest.webManifestUrl).toEqual(new URL(twaManifestJson.webManifestUrl!));
       expect(twaManifest.generatorApp).toEqual(twaManifestJson.generatorApp!);
+      expect(twaManifest.fallbackType).toBe('webview');
     });
 
-    it('TwaManifest.webManifestUrl defaults to undefined', () => {
+    it('Sets correct default values for optional fields', () => {
       const twaManifestJson = {
         packageId: 'com.pwa_directory.twa',
         host: 'pwa-directory.com',
@@ -181,6 +183,7 @@ describe('TwaManifest', () => {
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.webManifestUrl).toBeUndefined();
+      expect(twaManifest.fallbackType).toBe('customtabs');
     });
   });
 

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -72,6 +72,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.generateShortcuts())
           .toBe('[[name:\'shortcut name\', short_name:\'short\',' +
             ' url:\'https://pwa-directory.com/launch\', icon:\'shortcut_0\']]');
+      expect(twaManifest.fallbackType).toBe('customtabs');
     });
 
     it('Sets correct defaults for unavailable fields', () => {

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -36,7 +36,10 @@ def twaManifest = [
     shortcuts: <%= generateShortcuts() %>,
     // The duration of fade out animation in milliseconds to be played when removing splash screen.
     splashScreenFadeOutDuration: <%= splashScreenFadeOutDuration %>,
-    generatorApp: '<%= generatorApp %>' // Apllication that generated the Android Project
+    generatorApp: '<%= generatorApp %>', // Apllication that generated the Android Project
+    // The fallback strategy for when Trusted Web Activity is not avilable. Possible values are
+    // 'customtabs' and 'webview'.
+    fallbackType: '<%= fallbackType %>'
 ]
 
 android {
@@ -110,6 +113,8 @@ android {
         resValue "integer", "splashScreenFadeOutDuration", twaManifest.splashScreenFadeOutDuration.toString()
 
         resValue "string", "generatorApp", twaManifest.generatorApp
+
+        resValue "string", "fallbackType", twaManifest.fallbackType
     }
     buildTypes {
         release {
@@ -161,5 +166,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.1.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.2.0'
 }

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -36,7 +36,7 @@ def twaManifest = [
     shortcuts: <%= generateShortcuts() %>,
     // The duration of fade out animation in milliseconds to be played when removing splash screen.
     splashScreenFadeOutDuration: <%= splashScreenFadeOutDuration %>,
-    generatorApp: '<%= generatorApp %>', // Apllication that generated the Android Project
+    generatorApp: '<%= generatorApp %>', // Application that generated the Android Project
     // The fallback strategy for when Trusted Web Activity is not avilable. Possible values are
     // 'customtabs' and 'webview'.
     fallbackType: '<%= fallbackType %>'

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -21,7 +21,10 @@
      the abbreviated format. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="<%= packageId %>">
-    <uses-permission android:name="android.permission.INTERNET"/>
+
+    <% if (fallbackType === 'webview') { %>
+        <uses-permission android:name="android.permission.INTERNET"/>
+    <% }%>
 
     <application
         android:allowBackup="true"

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
      the abbreviated format. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="<%= packageId %>">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:allowBackup="true"
@@ -70,6 +71,9 @@
 
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
 
+            <meta-data android:name="android.support.customtabs.trusted.FALLBACK_STRATEGY"
+                android:value="@string/fallbackType" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -85,6 +89,9 @@
         </activity>
 
         <activity android:name="com.google.androidbrowserhelper.trusted.FocusActivity" />
+
+        <activity android:name="com.google.androidbrowserhelper.trusted.WebViewFallbackActivity"
+            android:configChanges="orientation|screenSize" />
 
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
- Updates to using android-browser-helper-1.2.0
- Adds an option to enable the WebView fallback on the twa-manifest.json