### PR TITLE
Adds a validator module to Bubblewrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ projects for Android Applications that launch Progressive Web App (PWA) using
 
 ## Bubblewrap Components
 
-- **[bubblewrap/core](./packages/core):** a javascript library for generating, building and updating TWA projects.
+- **[bubblewrap/core](./packages/core):** a javascript library for generating, building and
+updating TWA projects.
 - **[bubblewrap/cli](./packages/cli):** a command-line version of Bubblewrap.
+- **[bubblewrap/validator](./packages/validator):** library to validate the correctness and
+compare Trusted Web Activitty projects against the quality criteria.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ projects for Android Applications that launch Progressive Web App (PWA) using
 updating TWA projects.
 - **[bubblewrap/cli](./packages/cli):** a command-line version of Bubblewrap.
 - **[bubblewrap/validator](./packages/validator):** library to validate the correctness and
-compare Trusted Web Activitty projects against the quality criteria.
+compare Trusted Web Activity projects against the quality criteria.
 
 ## Contributing
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -152,6 +152,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "@types/minimist": "^1.2.0",
     "@types/valid-url": "^1.0.2",
     "color": "^3.1.2",
+    "colors": "^1.4.0",
     "inquirer": "^7.0.4",
     "minimist": "^1.2.2",
     "valid-url": "^1.0.9"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@bubblewrap/core": "^0.6.0",
+    "@bubblewrap/validator": "^0.6.0",
     "@types/color": "^3.0.0",
     "@types/inquirer": "^6.5.0",
     "@types/minimist": "^1.2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,18 +17,23 @@
 import {Cli} from './lib/Cli';
 import {Log} from '@bubblewrap/core';
 
-module.exports = (): void => {
+module.exports = async (): Promise<void> => {
   const cli = new Cli();
   const log = new Log('cli');
   const args = process.argv.slice(2);
-  cli.run(args)
-      .then((result) => {
-        if (!result) {
-          process.exit(1);
-        }
-      })
-      .catch((err: Error) => {
-        log.error(err.message);
-        process.exit(1);
-      });
+
+  let success;
+  try {
+    success = await cli.run(args);
+  } catch (err) {
+    log.error(err.message);
+    success = false;
+  }
+
+  // If running the command fails, we terminate the process signaling an error has occured.
+  // This helps if the CLI is being used as part of a build process and depends on its result
+  // to abort the build.
+  if (!success) {
+    process.exit(1);
+  }
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,11 @@ module.exports = (): void => {
   const log = new Log('cli');
   const args = process.argv.slice(2);
   cli.run(args)
+      .then((result) => {
+        if (!result) {
+          process.exit(1);
+        }
+      })
       .catch((err: Error) => {
         log.error(err.message);
         process.exit(1);

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -19,6 +19,7 @@ import {update} from './cmds/update';
 import {help} from './cmds/help';
 import {build} from './cmds/build';
 import {init} from './cmds/init';
+import {validate} from './cmds/validate';
 import {loadOrCreateConfig} from './config';
 
 export class Cli {
@@ -36,6 +37,8 @@ export class Cli {
         return await update(parsedArgs);
       case 'build':
         return await build(config);
+      case 'validate':
+        return await validate(parsedArgs);
       default:
         throw new Error(`"${command}" is not a valid command!`);
     }

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -23,7 +23,7 @@ import {validate} from './cmds/validate';
 import {loadOrCreateConfig} from './config';
 
 export class Cli {
-  async run(args: string[]): Promise<void> {
+  async run(args: string[]): Promise<boolean> {
     const config = await loadOrCreateConfig();
 
     const parsedArgs = minimist(args);
@@ -36,7 +36,7 @@ export class Cli {
       case 'update':
         return await update(parsedArgs);
       case 'build':
-        return await build(config);
+        return await build(config, parsedArgs);
       case 'validate':
         return await validate(parsedArgs);
       default:

--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -113,8 +113,7 @@ export async function build(
     const pwaValidationResult = (await pwaValidationPromise)!;
     printValidationResult(pwaValidationResult, log);
     if (pwaValidationResult.status === 'FAIL') {
-      log.error('PWA Quality Criteria check failed. Aborting build.');
-      return false;
+      log.warn('PWA Quality Criteria check failed.');
     }
   }
 

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -27,6 +27,8 @@ const HELP_MESSAGES = new Map<string, string>(
         'help ................ shows this menu',
         'init ................ initializes a new TWA Project',
         'update .............. updates an existing TWA Project with the latest bubblewrap template',
+        'validate ............ validates if an URL matches the PWA Quality Criteria for Trusted' +
+            ' Web Activity',
       ].join('\n')],
       ['init', [
         'Usage:',
@@ -57,6 +59,12 @@ const HELP_MESSAGES = new Map<string, string>(
             '--skipVersionUpgrade is used',
         '--skipVersionUpgrade ....... skips upgrading appVersion and appVersionCode',
         '--manifest ................. directory where the client should look for twa-manifest.json',
+      ].join('\n')],
+      ['validate', [
+        'Usage:',
+        '',
+        '',
+        'bubblewrap validate --url=[pwa-url]',
       ].join('\n')],
     ],
 );

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -46,6 +46,10 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         '',
         'bubblewrap build',
+        '',
+        '',
+        'Options:',
+        '--skipPwaValidation ....... skips validating the wrapped PWA against the Quality Criteria',
       ].join('\n')],
       ['update', [
         'Usage:',
@@ -69,12 +73,12 @@ const HELP_MESSAGES = new Map<string, string>(
     ],
 );
 
-export async function help(args: ParsedArgs, log = new Log('help')): Promise<void> {
+export async function help(args: ParsedArgs, log = new Log('help')): Promise<boolean> {
   // minimist uses an `_` object to store details.
   const command = args._[1];
   const message = HELP_MESSAGES.get(command) || HELP_MESSAGES.get('main');
 
   // We know we have a message for 'main', in case the command is invalid.
   log.info(message!);
-  return;
+  return true;
 }

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -195,7 +195,7 @@ async function createSigningKey(twaManifest: TwaManifest, config: Config): Promi
   });
 }
 
-export async function init(args: ParsedArgs, config: Config): Promise<void> {
+export async function init(args: ParsedArgs, config: Config): Promise<boolean> {
   log.info('Fetching Manifest: ', args.manifest);
   let twaManifest = await TwaManifest.fromWebManifest(args.manifest);
   twaManifest = await confirmTwaConfig(twaManifest);
@@ -204,4 +204,5 @@ export async function init(args: ParsedArgs, config: Config): Promise<void> {
   await twaManifest.saveToFile('./twa-manifest.json');
   await twaGenerator.createTwaProject(targetDirectory, twaManifest);
   await createSigningKey(twaManifest, config);
+  return true;
 }

--- a/packages/cli/src/lib/cmds/update.ts
+++ b/packages/cli/src/lib/cmds/update.ts
@@ -70,7 +70,7 @@ async function updateVersions(twaManifest: TwaManifest, appVersionNameArg: strin
  * @param {string} [args.appVersionName] Value to be used for appVersionName when upgrading
  * versions. Ignored if `args.skipVersionUpgrade` is set to true.
  */
-export async function update(args: ParsedArgs): Promise<void> {
+export async function update(args: ParsedArgs): Promise<boolean> {
   const targetDirectory = args.directory || process.cwd();
   const manifestFile = args.manifest || path.join(process.cwd(), 'twa-manifest.json');
   const twaManifest = await TwaManifest.fromFile(manifestFile);
@@ -86,5 +86,6 @@ export async function update(args: ParsedArgs): Promise<void> {
   }
 
   const twaGenerator = new TwaGenerator();
-  return await twaGenerator.createTwaProject(targetDirectory, twaManifest);
+  await twaGenerator.createTwaProject(targetDirectory, twaManifest);
+  return true;
 }

--- a/packages/cli/src/lib/cmds/validate.ts
+++ b/packages/cli/src/lib/cmds/validate.ts
@@ -21,6 +21,11 @@ import {printValidationResult} from '../pwaValidationHelper';
 
 const log = new Log('validate');
 
+/**
+ * Runs the PwaValidator to check a given URL agains the Quality criteria. More information on the
+ * Quality Criteria available at: https://web.dev/using-a-pwa-in-your-android-app/#quality-criteria
+ * @param {ParsedArgs} args
+ */
 export async function validate(args: ParsedArgs): Promise<boolean> {
   log.info('Validating URL: ', args.url);
   const validationResult = await PwaValidator.validate(new URL(args.url));

--- a/packages/cli/src/lib/cmds/validate.ts
+++ b/packages/cli/src/lib/cmds/validate.ts
@@ -17,11 +17,13 @@
 import {PwaValidator} from '@bubblewrap/validator';
 import {Log} from '@bubblewrap/core';
 import {ParsedArgs} from 'minimist';
+import {printValidationResult} from '../pwaValidationHelper';
 
 const log = new Log('validate');
 
-export async function validate(args: ParsedArgs): Promise<void> {
+export async function validate(args: ParsedArgs): Promise<boolean> {
   log.info('Validating URL: ', args.url);
   const validationResult = await PwaValidator.validate(new URL(args.url));
-  console.log(validationResult);
+  printValidationResult(validationResult, log);
+  return validationResult.status === 'PASS';
 }

--- a/packages/cli/src/lib/cmds/validate.ts
+++ b/packages/cli/src/lib/cmds/validate.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {PwaValidator} from '@bubblewrap/validator';
+import {Log} from '@bubblewrap/core';
+import {ParsedArgs} from 'minimist';
+
+const log = new Log('validate');
+
+export async function validate(args: ParsedArgs): Promise<void> {
+  log.info('Validating URL: ', args.url);
+  const validationResult = await PwaValidator.validate(new URL(args.url));
+  console.log(validationResult);
+}

--- a/packages/cli/src/lib/pwaValidationHelper.ts
+++ b/packages/cli/src/lib/pwaValidationHelper.ts
@@ -3,6 +3,11 @@ import {red, green, bold, underline, gray} from 'colors';
 import {Log} from '@bubblewrap/core';
 
 export function printValidationResult(validationResult: PwaValidationResult, log: Log): void {
+  log.info('');
+  log.info('Check the full PageSpeed Insights report at:');
+  log.info(`- ${validationResult.psiWebUrl}`);
+  log.info('');
+
   const performanceValue = validationResult.scores.performance.status === 'PASS' ?
   green(validationResult.scores.performance.printValue) :
   red(validationResult.scores.performance.printValue);

--- a/packages/cli/src/lib/pwaValidationHelper.ts
+++ b/packages/cli/src/lib/pwaValidationHelper.ts
@@ -1,0 +1,29 @@
+import {PwaValidationResult} from '@bubblewrap/validator';
+import {red, green, bold, underline, gray} from 'colors';
+import {Log} from '@bubblewrap/core';
+
+export function printValidationResult(validationResult: PwaValidationResult, log: Log): void {
+  const performanceValue = validationResult.scores.performance.status === 'PASS' ?
+  green(validationResult.scores.performance.printValue) :
+  red(validationResult.scores.performance.printValue);
+
+  const pwaValue = validationResult.scores.pwa.status === 'PASS' ?
+  green(validationResult.scores.pwa.printValue) :
+  red(validationResult.scores.pwa.printValue);
+
+  const overallStatus = validationResult.status === 'PASS' ?
+  green(validationResult.status) : red(validationResult.status);
+
+  const accessibilityValue = gray(validationResult.scores.accessibility.printValue);
+
+  log.info('');
+  log.info(underline('Quality Criteria scores'));
+  log.info(`Lighthouse Performance score: ......... ${performanceValue}`);
+  log.info(`Lighthouse PWA check: ................. ${pwaValue}`);
+  log.info('');
+  log.info(underline('Other scores'));
+  log.info(`Lighthouse Accessibility score......... ${accessibilityValue}`);
+  log.info('');
+  log.info(underline('Summary'));
+  log.info(bold(`Overall result: ....................... ${overallStatus}`));
+}

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,0 +1,24 @@
+<!---
+
+  Copyright 2019 Google Inc. All Rights Reserved.
+ 
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+       http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+# Bubblewrap Validator
+
+Bubblewrap Validator is a JavaScript library that helps developers to verify if their
+[Trusted Web Activity][1] project is well formed as well as validating if the Progressive Web
+App(PWA) used inside it matchs the [minimun quality criteria][2].
+
+[1]: https://developers.google.com/web/android/trusted-web-activity/
+[2]: https://web.dev/using-a-pwa-in-your-android-app/#quality-criteria

--- a/packages/validator/jasmine.json
+++ b/packages/validator/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "dist/spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "@bubblewrap/validator",
+  "version": "0.6.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/jasmine": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.10.tgz",
+      "integrity": "sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew=="
+    },
+    "@types/node": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
+      "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    }
+  }
+}

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bubblewrap/validator",
+  "version": "0.6.0",
+  "description": "Validate if an app using Trusted Web Activity fulfills the quality criteria",
+  "bin": {
+    "bubblewrap": "bin/bubblewrap.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint \"src/**/*.{js,ts}\"",
+    "test": "tsc && jasmine --config=jasmine.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoogleChromeLabs/bubblewrap.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@types/node-fetch": "^2.5.5",
+    "@types/jasmine": "^3.5.0",
+    "node-fetch": "^2.6.0"
+  }
+}

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export * from './lib/PwaValidator';
+export * from './lib/psi/PsiResult';

--- a/packages/validator/src/lib/PwaValidator.ts
+++ b/packages/validator/src/lib/PwaValidator.ts
@@ -33,6 +33,7 @@ export type PwaValidationResult = {
     performance: ScoreResult;
     accessibility: ScoreResult;
   };
+  readonly psiWebUrl: string;
   readonly status: ValidationResult;
 }
 
@@ -73,9 +74,12 @@ export class PwaValidator {
     const performancePass = performanceScore >= MIN_PERFORMANCE_SCORE;
     const passed = pwaPass && performancePass;
     const accessibilityScore = psiResult.lighthouseResult.categories.accessibility.score;
+    const psiWebUrl = new URL('https://developers.google.com/speed/pagespeed/insights/');
+    psiWebUrl.searchParams.append('url', url.toString());
 
     return {
       status: passed ? 'PASS' : 'FAIL',
+      psiWebUrl: psiWebUrl.toString(),
       scores: {
         accessibility: {
           value: accessibilityScore,

--- a/packages/validator/src/lib/PwaValidator.ts
+++ b/packages/validator/src/lib/PwaValidator.ts
@@ -64,6 +64,11 @@ export class PwaValidator {
     const psiResult = await this.psi.runPageSpeedInsights(psiRequest);
     const pwaScore = psiResult.lighthouseResult.categories.pwa.score;
     const performanceScore = psiResult.lighthouseResult.categories.performance.score;
+    if (pwaScore === null || performanceScore === null || isNaN(pwaScore) ||
+        isNaN(performanceScore)) {
+      throw new Error(`Invalid scores received. PWA Score: ${pwaScore}. ` +
+          `Performance Score: ${performanceScore}`);
+    }
     const pwaPass = pwaScore >= MIN_PWA_SCORE;
     const performancePass = performanceScore >= MIN_PERFORMANCE_SCORE;
     const passed = pwaPass && performancePass;

--- a/packages/validator/src/lib/PwaValidator.ts
+++ b/packages/validator/src/lib/PwaValidator.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {PsiRequestBuilder, PageSpeedInsights} from './psi';
+
+const MIN_PERFORMANCE_SCORE = 0.8;
+const REQUIRED_PWA_SCORE = 1;
+
+export type PwaValidationResult = {
+  readonly performanceScore: number;
+  readonly pwaScore: number;
+  readonly passed: boolean;
+}
+
+/**
+ * Validates if a Progressive Web App (PWA) passes the Quality Criteria to be used inside a Trusted
+ * Web Activity.
+ * PWAs are required to have a minimum Lighthouse performance score of 80 and a PWA score of 1.
+ *
+ * More information on the Quality criteria here:
+ * -  https://web.dev/using-a-pwa-in-your-android-app/#quality-criteria
+ */
+export class PwaValidator {
+  constructor(readonly psi: PageSpeedInsights) {
+  }
+
+  /**
+   * Triggers validation for an URL.
+   * @param {URL} url the URL to be validated.
+   * @returns {PwaValidationResult} the result of the validation.
+   */
+  async validate(url: URL): Promise<PwaValidationResult> {
+    const psiRequest = new PsiRequestBuilder(url)
+        .addCategory('performance')
+        .addCategory('pwa')
+        .setStrategy('mobile')
+        .build();
+
+    const psiResult = await this.psi.runPageSpeedInsights(psiRequest);
+    const pwaScore = psiResult.lighthouseResult.categories.pwa.score;
+    const performanceScore = psiResult.lighthouseResult.categories.performance.score;
+    const passed = pwaScore >= REQUIRED_PWA_SCORE && performanceScore >= MIN_PERFORMANCE_SCORE;
+    return {
+      performanceScore: performanceScore,
+      pwaScore: pwaScore,
+      passed: passed,
+    };
+  }
+
+  /**
+   * A shortcut method to invoke PwaBuilder#validate with the default PageSpeedInsight
+   * implementation.
+   * @param url the URL to be validated.
+   * @returns {PwaValidationResult} the result of the validation.
+   */
+  static async validate(url: URL): Promise<PwaValidationResult> {
+    const validator = new PwaValidator(new PageSpeedInsights());
+    return await validator.validate(url);
+  }
+}

--- a/packages/validator/src/lib/psi/PageSpeedInsights.ts
+++ b/packages/validator/src/lib/psi/PageSpeedInsights.ts
@@ -34,7 +34,8 @@ export class PsiRequest {
 }
 
 /**
- * Builds requests for the PSI endpoint;
+ * Builds requests for the PSI endpoint. A full list of parameters is available at
+ * https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed
  */
 export class PsiRequestBuilder {
   private url: URL;
@@ -89,12 +90,17 @@ export class PsiRequestBuilder {
 /**
  * A Wrapper for the PageSpeedInsights API.
  *
- * More information on the API is available on the following link:
+ * More information on the API is available at:
  * - https://developers.google.com/speed/docs/insights/v5/get-started
  */
 export class PageSpeedInsights {
   async runPageSpeedInsights(request: PsiRequest): Promise<PsiResult> {
-    const result = await fetch(request.url);
-    return (await result.json()) as PsiResult;
+    const response = await fetch(request.url);
+    if (response.status !== 200) {
+      throw new Error(
+          `Failed to run the PageSpeed Insight report for ${request.url}. ` +
+          `Server responded with status ${response.status}`);
+    }
+    return (await response.json()) as PsiResult;
   }
 }

--- a/packages/validator/src/lib/psi/PageSpeedInsights.ts
+++ b/packages/validator/src/lib/psi/PageSpeedInsights.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import fetch from 'node-fetch';
+import {PsiResult} from './PsiResult';
+
+const BASE_PSI_URL = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
+export type PsiStrategy = 'desktop' | 'mobile';
+export type PsiCategory = 'accessibility' | 'best-practices' | 'performance' | 'pwa' | 'seo';
+
+/**
+ * A wrapper for a request to the PageSpeed Ingights API.
+ */
+export class PsiRequest {
+  /**
+   * Builds a new PsiRequest;
+   * @param url the full URL of the PSI endpoint, with parameters
+   */
+  constructor(readonly url: URL) {
+  }
+}
+
+/**
+ * Builds requests for the PSI endpoint;
+ */
+export class PsiRequestBuilder {
+  private url: URL;
+
+  /**
+   * Constructs a new PsiRequestBuilder instance
+   * @param validationUrl the URL to be validated
+   */
+  constructor(validationUrl: URL) {
+    this.url = new URL(BASE_PSI_URL);
+    this.setUrl(validationUrl);
+  }
+
+  /**
+   * Sets the URL to be validated
+   * @param url the URL to be validated
+   */
+  setUrl(url: URL): PsiRequestBuilder {
+    this.url.searchParams.delete('url');
+    this.url.searchParams.append('url', url.toString());
+    return this;
+  }
+
+  /**
+   * Sets the strategy to use when validating a PWA.
+   * @param {PsiStrategy} strategy
+   */
+  setStrategy(strategy: PsiStrategy): PsiRequestBuilder {
+    this.url.searchParams.delete('strategy');
+    this.url.searchParams.append('strategy', strategy);
+    return this;
+  }
+
+  /**
+   * Adds a category to be added when generating the PSI report.
+   * @param {PsiCategory} category
+   */
+  addCategory(category: PsiCategory): PsiRequestBuilder {
+    this.url.searchParams.append('category', category);
+    return this;
+  }
+
+  /**
+   * Builds a PsiRequest using the parameters in this builder.
+   * @returns {PsiRequest}
+   */
+  build(): PsiRequest {
+    return new PsiRequest(this.url);
+  }
+}
+
+/**
+ * A Wrapper for the PageSpeedInsights API.
+ *
+ * More information on the API is available on the following link:
+ * - https://developers.google.com/speed/docs/insights/v5/get-started
+ */
+export class PageSpeedInsights {
+  async runPageSpeedInsights(request: PsiRequest): Promise<PsiResult> {
+    const result = await fetch(request.url);
+    return (await result.json()) as PsiResult;
+  }
+}

--- a/packages/validator/src/lib/psi/PsiResult.ts
+++ b/packages/validator/src/lib/psi/PsiResult.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export type LighthouseCategoryName =
+    'accessibility' | 'best-practices' | 'performance' | 'pwa' | 'seo';
+export type LighthouseEmulatedFormFactor = 'desktop' | 'mobile';
+export type LighthouseCategoryGroup = {
+  title: string;
+  description?: string;
+}
+export type LighthouseCategoryGroups = {
+  'pwa-installable': LighthouseCategoryGroup;
+  'seo-mobile': LighthouseCategoryGroup;
+  diagnostics: LighthouseCategoryGroup;
+  'a11y-best-practices': LighthouseCategoryGroup;
+  'seo-crawl': LighthouseCategoryGroup;
+  'a11y-color-contrast': LighthouseCategoryGroup;
+  'seo-content': LighthouseCategoryGroup;
+  'pwa-optimized': LighthouseCategoryGroup;
+  'a11y-navigation': LighthouseCategoryGroup;
+  'pwa-fast-reliable': LighthouseCategoryGroup;
+  'a11y-aria': LighthouseCategoryGroup;
+  'a11y-audio-video': LighthouseCategoryGroup;
+  'a11y-language': LighthouseCategoryGroup;
+  'a11y-tables-lists': LighthouseCategoryGroup;
+  'a11y-names-labels': LighthouseCategoryGroup;
+  budgets: LighthouseCategoryGroup;
+  metrics: LighthouseCategoryGroup;
+  'load-opportunities': LighthouseCategoryGroup;
+};
+
+export type LighthouseCategory = {
+  id: LighthouseCategoryName;
+  title: string;
+  description: string;
+  manualDescription: string;
+  score: number;
+  auditRef: LighthouseAuditRef[];
+}
+
+export type LighthouseAuditRef = {
+  id: string;
+  weight: number;
+  group?: string;
+}
+
+export type LighthouseCategories = {
+  [key in LighthouseCategoryName]: LighthouseCategory;
+};
+
+export type LighthouseI18n = {
+  rendererFormattedStrings: {
+    varianceDisclaimer: string;
+    opportunityResourceColumnLabel: string;
+    opportunitySavingsColumnLabel: string;
+    errorMissingAuditInfo: string;
+    errorLabel: string;
+    warningHeader: string;
+    auditGroupExpandTooltip: string;
+    passedAuditsGroupTitle: string;
+    notApplicableAuditsGroupTitle: string;
+    manualAuditsGroupTitle: string;
+    toplevelWarningsMessage: string;
+    crcLongestDurationLabel: string;
+    crcInitialNavigation: string;
+    lsPerformanceCategoryDescription: string;
+    labDataTitle: string;
+  };
+};
+
+export type DebugDataDetail = {
+  type: 'debugdata';
+  items: object[]; // TODO(andreban): Find type
+}
+
+export type DebugDataTable = { // TODO 'third-party-summary' has more deetails
+  type: 'table';
+  summary: object;
+  headings: object[];// TODO(andreban): Find type
+  items: object[];// TODO(andreban): Find type
+}
+
+export type DebugDataOpportunity = {
+  type: 'opportunity';
+  overallSavingsMs: number;
+  overallSavingsBytes?: number;
+  headings: object[]; // TODO(andreban): Find type
+  items: object[]; // TODO(andreban): Find type
+}
+
+export type DebugDataCriticalRequestChain = {
+  type: 'criticalrequestchain';
+  chains: object[]; // TODO(andreban): Find type
+  logestChain: object[]; // TODO(andreban): Find type
+}
+
+export type DebugDataScreenshot = {
+  type: 'screenshot';
+  timing: number;
+  timestamp: number;
+  data: string;
+}
+
+export type DebugDataFilmStrip = {
+  type: 'filmstrip';
+  items: object[];// TODO(andreban): Find type
+  scale: number;
+}
+
+export type LighthouseAudit<T> = {
+  id: string;
+  title: string;
+  description: string;
+  score?: number;
+  scoreDisplayMode: string; // 'informative' | 'numeric' | 'manual' | 'binary' | 'notApplicable'
+  details?: T; // TODO(andreban): Each score has its specific details.
+  numericValue: number;
+  warnings: object[]; // TODO(andreban): Find type
+}
+
+export type LighthouseAudits = {
+  'main-thread-tasks': LighthouseAudit<DebugDataTable>;
+  'total-blocking-time': LighthouseAudit<void>;
+  'viewport': LighthouseAudit<void>;
+  'uses-rel-preconnect': LighthouseAudit<DebugDataOpportunity>;
+  'bootup-time': LighthouseAudit<DebugDataTable>;
+  'network-server-latency': LighthouseAudit<DebugDataTable>;
+  'offscreen-images': LighthouseAudit<DebugDataOpportunity>;
+  'uses-responsive-images': LighthouseAudit<DebugDataOpportunity>;
+  'speed-index': LighthouseAudit<void>;
+  'first-cpu-idle': LighthouseAudit<void>;
+  'total-byte-weight': LighthouseAudit<DebugDataTable>;
+  'mainthread-work-breakdown': LighthouseAudit<DebugDataTable>;
+  'first-contentful-paint': LighthouseAudit<void>;
+  'critical-request-chains': LighthouseAudit<DebugDataCriticalRequestChain>;
+  'dom-size': LighthouseAudit<DebugDataTable>;
+  'uses-rel-preload': LighthouseAudit<DebugDataOpportunity>;
+  'performance-budget': LighthouseAudit<void>;
+  'unminified-javascript': LighthouseAudit<DebugDataOpportunity>;
+  'first-meaningful-paint': LighthouseAudit<void>;
+  'resource-summary': LighthouseAudit<DebugDataTable>;
+  'pwa-cross-browser': LighthouseAudit<void>;
+  'installable-manifest': LighthouseAudit<DebugDataOpportunity>;
+  'themed-omnibox': LighthouseAudit<DebugDataOpportunity>;
+  'efficient-animated-content': LighthouseAudit<DebugDataOpportunity>;
+  'final-screenshot': LighthouseAudit<DebugDataScreenshot>;
+  'metrics': LighthouseAudit<DebugDataDetail>;
+  'network-requests': LighthouseAudit<DebugDataTable>;
+  'uses-long-cache-ttl': LighthouseAudit<DebugDataTable>;
+  'max-potential-fid': LighthouseAudit<void>;
+  'interactive': LighthouseAudit<void>;
+  'screenshot-thumbnails': LighthouseAudit<DebugDataFilmStrip>;
+  'network-rtt': LighthouseAudit<DebugDataTable>;
+  'load-fast-enough-for-pwa': LighthouseAudit<void>;
+  'pwa-page-transitions': LighthouseAudit<void>;
+  'apple-touch-icon': LighthouseAudit<void>;
+  'font-display': LighthouseAudit<DebugDataTable>;
+  'estimated-input-latency': LighthouseAudit<void>;
+  'content-width': LighthouseAudit<void>;
+  'pwa-each-page-has-url': LighthouseAudit<void>;
+  'unminified-css': LighthouseAudit<DebugDataOpportunity>;
+  'unused-css-rules': LighthouseAudit<DebugDataOpportunity>;
+  'redirects-http': LighthouseAudit<void>;
+  'uses-webp-images': LighthouseAudit<DebugDataOpportunity>;
+  'diagnostics': LighthouseAudit<DebugDataDetail>;
+  'redirects': LighthouseAudit<DebugDataOpportunity>;
+  'is-on-https': LighthouseAudit<DebugDataTable>;
+  'without-javascript': LighthouseAudit<void>;
+  'works-offline': LighthouseAudit<void>;
+  'user-timings': LighthouseAudit<DebugDataTable>;
+  'splash-screen': LighthouseAudit<DebugDataDetail>;
+  'time-to-first-byte': LighthouseAudit<DebugDataOpportunity>;
+  'render-blocking-resources': LighthouseAudit<DebugDataOpportunity>;
+  'uses-optimized-images': LighthouseAudit<DebugDataOpportunity>;
+  'service-worker': LighthouseAudit<void>;
+  'uses-text-compression': LighthouseAudit<DebugDataOpportunity>;
+  'third-party-summary': LighthouseAudit<DebugDataTable>;
+  'offline-start-url': LighthouseAudit<void>;
+}
+
+export type PsiLighthouseResult = {
+  requestedUrl: string;
+  finalUrl: string;
+  lighthouseVersion: string;
+  userAgent: string;
+  fetchTime: string;
+  environment: {
+    networkUserAgent: string;
+    hostUserAgent: string;
+    benchmarkIndes: number;
+  };
+  runWarnings: object[]; // TODO(andreban): Figure out what the content of a warning should be.
+  configSettings: {
+    emulatedFormFactor: LighthouseEmulatedFormFactor;
+    locale: string;
+    onlyCategories: LighthouseCategoryName[];
+    channel: string;
+  };
+  audits: LighthouseAudits;
+  categories: LighthouseCategories;
+  categoryGroups: LighthouseCategoryGroups;
+  timing: {
+    total: number;
+  };
+  i18n: LighthouseI18n;
+};
+
+/**
+ * Defines the types fro the PSI API response.
+ */
+export type PsiResult = {
+  captchaResult: string;
+  kind: string;
+  id: string;
+  loadingExperiente: {
+    initial_url: string;
+  };
+  lighthouseResult: PsiLighthouseResult;
+  analysisUTCTimestamp: string;
+  version: {
+    major: number;
+    minor: number;
+  };
+};

--- a/packages/validator/src/lib/psi/PsiResult.ts
+++ b/packages/validator/src/lib/psi/PsiResult.ts
@@ -54,7 +54,9 @@ export type PsiLighthouseResult = {
 };
 
 /**
- * Defines the types fro the PSI API response.
+ * Defines the types from the PageSpeed Insights API response, relevant to the Trusted Web Activity
+ * validation. A comprehensive documentation on fields available for the API response is available
+ * at https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed#response_1.
  */
 export type PsiResult = {
   captchaResult: string;

--- a/packages/validator/src/lib/psi/PsiResult.ts
+++ b/packages/validator/src/lib/psi/PsiResult.ts
@@ -17,30 +17,6 @@
 export type LighthouseCategoryName =
     'accessibility' | 'best-practices' | 'performance' | 'pwa' | 'seo';
 export type LighthouseEmulatedFormFactor = 'desktop' | 'mobile';
-export type LighthouseCategoryGroup = {
-  title: string;
-  description?: string;
-}
-export type LighthouseCategoryGroups = {
-  'pwa-installable': LighthouseCategoryGroup;
-  'seo-mobile': LighthouseCategoryGroup;
-  diagnostics: LighthouseCategoryGroup;
-  'a11y-best-practices': LighthouseCategoryGroup;
-  'seo-crawl': LighthouseCategoryGroup;
-  'a11y-color-contrast': LighthouseCategoryGroup;
-  'seo-content': LighthouseCategoryGroup;
-  'pwa-optimized': LighthouseCategoryGroup;
-  'a11y-navigation': LighthouseCategoryGroup;
-  'pwa-fast-reliable': LighthouseCategoryGroup;
-  'a11y-aria': LighthouseCategoryGroup;
-  'a11y-audio-video': LighthouseCategoryGroup;
-  'a11y-language': LighthouseCategoryGroup;
-  'a11y-tables-lists': LighthouseCategoryGroup;
-  'a11y-names-labels': LighthouseCategoryGroup;
-  budgets: LighthouseCategoryGroup;
-  metrics: LighthouseCategoryGroup;
-  'load-opportunities': LighthouseCategoryGroup;
-};
 
 export type LighthouseCategory = {
   id: LighthouseCategoryName;
@@ -48,148 +24,11 @@ export type LighthouseCategory = {
   description: string;
   manualDescription: string;
   score: number;
-  auditRef: LighthouseAuditRef[];
-}
-
-export type LighthouseAuditRef = {
-  id: string;
-  weight: number;
-  group?: string;
 }
 
 export type LighthouseCategories = {
   [key in LighthouseCategoryName]: LighthouseCategory;
 };
-
-export type LighthouseI18n = {
-  rendererFormattedStrings: {
-    varianceDisclaimer: string;
-    opportunityResourceColumnLabel: string;
-    opportunitySavingsColumnLabel: string;
-    errorMissingAuditInfo: string;
-    errorLabel: string;
-    warningHeader: string;
-    auditGroupExpandTooltip: string;
-    passedAuditsGroupTitle: string;
-    notApplicableAuditsGroupTitle: string;
-    manualAuditsGroupTitle: string;
-    toplevelWarningsMessage: string;
-    crcLongestDurationLabel: string;
-    crcInitialNavigation: string;
-    lsPerformanceCategoryDescription: string;
-    labDataTitle: string;
-  };
-};
-
-export type DebugDataDetail = {
-  type: 'debugdata';
-  items: object[]; // TODO(andreban): Find type
-}
-
-export type DebugDataTable = { // TODO 'third-party-summary' has more deetails
-  type: 'table';
-  summary: object;
-  headings: object[];// TODO(andreban): Find type
-  items: object[];// TODO(andreban): Find type
-}
-
-export type DebugDataOpportunity = {
-  type: 'opportunity';
-  overallSavingsMs: number;
-  overallSavingsBytes?: number;
-  headings: object[]; // TODO(andreban): Find type
-  items: object[]; // TODO(andreban): Find type
-}
-
-export type DebugDataCriticalRequestChain = {
-  type: 'criticalrequestchain';
-  chains: object[]; // TODO(andreban): Find type
-  logestChain: object[]; // TODO(andreban): Find type
-}
-
-export type DebugDataScreenshot = {
-  type: 'screenshot';
-  timing: number;
-  timestamp: number;
-  data: string;
-}
-
-export type DebugDataFilmStrip = {
-  type: 'filmstrip';
-  items: object[];// TODO(andreban): Find type
-  scale: number;
-}
-
-export type LighthouseAudit<T> = {
-  id: string;
-  title: string;
-  description: string;
-  score?: number;
-  scoreDisplayMode: string; // 'informative' | 'numeric' | 'manual' | 'binary' | 'notApplicable'
-  details?: T; // TODO(andreban): Each score has its specific details.
-  numericValue: number;
-  warnings: object[]; // TODO(andreban): Find type
-}
-
-export type LighthouseAudits = {
-  'main-thread-tasks': LighthouseAudit<DebugDataTable>;
-  'total-blocking-time': LighthouseAudit<void>;
-  'viewport': LighthouseAudit<void>;
-  'uses-rel-preconnect': LighthouseAudit<DebugDataOpportunity>;
-  'bootup-time': LighthouseAudit<DebugDataTable>;
-  'network-server-latency': LighthouseAudit<DebugDataTable>;
-  'offscreen-images': LighthouseAudit<DebugDataOpportunity>;
-  'uses-responsive-images': LighthouseAudit<DebugDataOpportunity>;
-  'speed-index': LighthouseAudit<void>;
-  'first-cpu-idle': LighthouseAudit<void>;
-  'total-byte-weight': LighthouseAudit<DebugDataTable>;
-  'mainthread-work-breakdown': LighthouseAudit<DebugDataTable>;
-  'first-contentful-paint': LighthouseAudit<void>;
-  'critical-request-chains': LighthouseAudit<DebugDataCriticalRequestChain>;
-  'dom-size': LighthouseAudit<DebugDataTable>;
-  'uses-rel-preload': LighthouseAudit<DebugDataOpportunity>;
-  'performance-budget': LighthouseAudit<void>;
-  'unminified-javascript': LighthouseAudit<DebugDataOpportunity>;
-  'first-meaningful-paint': LighthouseAudit<void>;
-  'resource-summary': LighthouseAudit<DebugDataTable>;
-  'pwa-cross-browser': LighthouseAudit<void>;
-  'installable-manifest': LighthouseAudit<DebugDataOpportunity>;
-  'themed-omnibox': LighthouseAudit<DebugDataOpportunity>;
-  'efficient-animated-content': LighthouseAudit<DebugDataOpportunity>;
-  'final-screenshot': LighthouseAudit<DebugDataScreenshot>;
-  'metrics': LighthouseAudit<DebugDataDetail>;
-  'network-requests': LighthouseAudit<DebugDataTable>;
-  'uses-long-cache-ttl': LighthouseAudit<DebugDataTable>;
-  'max-potential-fid': LighthouseAudit<void>;
-  'interactive': LighthouseAudit<void>;
-  'screenshot-thumbnails': LighthouseAudit<DebugDataFilmStrip>;
-  'network-rtt': LighthouseAudit<DebugDataTable>;
-  'load-fast-enough-for-pwa': LighthouseAudit<void>;
-  'pwa-page-transitions': LighthouseAudit<void>;
-  'apple-touch-icon': LighthouseAudit<void>;
-  'font-display': LighthouseAudit<DebugDataTable>;
-  'estimated-input-latency': LighthouseAudit<void>;
-  'content-width': LighthouseAudit<void>;
-  'pwa-each-page-has-url': LighthouseAudit<void>;
-  'unminified-css': LighthouseAudit<DebugDataOpportunity>;
-  'unused-css-rules': LighthouseAudit<DebugDataOpportunity>;
-  'redirects-http': LighthouseAudit<void>;
-  'uses-webp-images': LighthouseAudit<DebugDataOpportunity>;
-  'diagnostics': LighthouseAudit<DebugDataDetail>;
-  'redirects': LighthouseAudit<DebugDataOpportunity>;
-  'is-on-https': LighthouseAudit<DebugDataTable>;
-  'without-javascript': LighthouseAudit<void>;
-  'works-offline': LighthouseAudit<void>;
-  'user-timings': LighthouseAudit<DebugDataTable>;
-  'splash-screen': LighthouseAudit<DebugDataDetail>;
-  'time-to-first-byte': LighthouseAudit<DebugDataOpportunity>;
-  'render-blocking-resources': LighthouseAudit<DebugDataOpportunity>;
-  'uses-optimized-images': LighthouseAudit<DebugDataOpportunity>;
-  'service-worker': LighthouseAudit<void>;
-  'uses-text-compression': LighthouseAudit<DebugDataOpportunity>;
-  'third-party-summary': LighthouseAudit<DebugDataTable>;
-  'offline-start-url': LighthouseAudit<void>;
-}
 
 export type PsiLighthouseResult = {
   requestedUrl: string;
@@ -200,22 +39,18 @@ export type PsiLighthouseResult = {
   environment: {
     networkUserAgent: string;
     hostUserAgent: string;
-    benchmarkIndes: number;
+    benchmarkIndex: number;
   };
-  runWarnings: object[]; // TODO(andreban): Figure out what the content of a warning should be.
   configSettings: {
     emulatedFormFactor: LighthouseEmulatedFormFactor;
     locale: string;
     onlyCategories: LighthouseCategoryName[];
     channel: string;
   };
-  audits: LighthouseAudits;
   categories: LighthouseCategories;
-  categoryGroups: LighthouseCategoryGroups;
   timing: {
     total: number;
   };
-  i18n: LighthouseI18n;
 };
 
 /**

--- a/packages/validator/src/lib/psi/index.ts
+++ b/packages/validator/src/lib/psi/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export * from './PageSpeedInsights';
+export * from './PsiResult';

--- a/packages/validator/src/spec/PwaValidatorSpec.ts
+++ b/packages/validator/src/spec/PwaValidatorSpec.ts
@@ -44,22 +44,22 @@ describe('PwaValidator', () => {
     it('pass is true when lighthouse score >= 0.8 and pwa >= 1.0', async () => {
       const pwaValidator = mockPwaValidator(0.8, 1.0);
       const result = await pwaValidator.validate(new URL('https://example.com'));
-      expect(result.passed).toBeTrue();
+      expect(result.status).toBe('PASS');
     });
     it('pass is false when lighthouse score < 0.8 and pwa >= 1.0', async () => {
       const pwaValidator = mockPwaValidator(0.7, 1.0);
       const result = await pwaValidator.validate(new URL('https://example.com'));
-      expect(result.passed).toBeFalse();
+      expect(result.status).toBe('FAIL');
     });
     it('pass is false when lighthouse score >= 0.8 and pwa < 1.0', async () => {
       const pwaValidator = mockPwaValidator(1.0, 0.99);
       const result = await pwaValidator.validate(new URL('https://example.com'));
-      expect(result.passed).toBeFalse();
+      expect(result.status).toBe('FAIL');
     });
     it('pass is false when lighthouse score < 0.8 and pwa < 1.0', async () => {
       const pwaValidator = mockPwaValidator(0.0, 0.0);
       const result = await pwaValidator.validate(new URL('https://example.com'));
-      expect(result.passed).toBeFalse();
+      expect(result.status).toBe('FAIL');
     });
   });
 });

--- a/packages/validator/src/spec/PwaValidatorSpec.ts
+++ b/packages/validator/src/spec/PwaValidatorSpec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {PwaValidator} from '../lib/PwaValidator';
+import {PsiResult} from '../lib/psi';
+
+function mockPsiResult(performanceScore: number, pwaScore: number): PsiResult {
+  return {
+    lighthouseResult: {
+      categories: {
+        pwa: {
+          score: pwaScore,
+        },
+        performance: {
+          score: performanceScore,
+        },
+      },
+    },
+  } as PsiResult;
+};
+
+function mockPwaValidator(pwaScore: number, performanceScore: number): PwaValidator {
+  return new PwaValidator({
+    runPageSpeedInsights: async (): Promise<PsiResult> => {
+      return mockPsiResult(pwaScore, performanceScore);
+    },
+  });
+}
+
+describe('PwaValidator', () => {
+  describe('#validate', () => {
+    it('pass is true when lighthouse score >= 0.8 and pwa >= 1.0', async () => {
+      const pwaValidator = mockPwaValidator(0.8, 1.0);
+      const result = await pwaValidator.validate(new URL('https://example.com'));
+      expect(result.passed).toBeTrue();
+    });
+    it('pass is false when lighthouse score < 0.8 and pwa >= 1.0', async () => {
+      const pwaValidator = mockPwaValidator(0.7, 1.0);
+      const result = await pwaValidator.validate(new URL('https://example.com'));
+      expect(result.passed).toBeFalse();
+    });
+    it('pass is false when lighthouse score >= 0.8 and pwa < 1.0', async () => {
+      const pwaValidator = mockPwaValidator(1.0, 0.99);
+      const result = await pwaValidator.validate(new URL('https://example.com'));
+      expect(result.passed).toBeFalse();
+    });
+    it('pass is false when lighthouse score < 0.8 and pwa < 1.0', async () => {
+      const pwaValidator = mockPwaValidator(0.0, 0.0);
+      const result = await pwaValidator.validate(new URL('https://example.com'));
+      expect(result.passed).toBeFalse();
+    });
+  });
+});

--- a/packages/validator/src/spec/PwaValidatorSpec.ts
+++ b/packages/validator/src/spec/PwaValidatorSpec.ts
@@ -91,5 +91,13 @@ describe('PwaValidator', () => {
       await expectAsync(pwaValidator.validate(new URL('https://example.com')))
           .toBeRejectedWithError();
     });
+    it('returns the correct PSI url', async () => {
+      const psiResult = mockPsiResult(0.8, 1.0);
+      const pwaValidator = mockPwaValidator(psiResult);
+      const result = await pwaValidator.validate(new URL('https://example.com'));
+      expect(result.psiWebUrl)
+          .toBe('https://developers.google.com/speed/pagespeed/insights/' +
+              '?url=https%3A%2F%2Fexample.com%2F');
+    });
   });
 });

--- a/packages/validator/src/spec/PwaValidatorSpec.ts
+++ b/packages/validator/src/spec/PwaValidatorSpec.ts
@@ -26,6 +26,9 @@ function mockPsiResult(performanceScore: number, pwaScore: number): PsiResult {
         performance: {
           score: performanceScore,
         },
+        accessibility: {
+          score: 0,
+        },
       },
     },
   } as PsiResult;

--- a/packages/validator/src/spec/psi/PageSpeedInsightsSpec.ts
+++ b/packages/validator/src/spec/psi/PageSpeedInsightsSpec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {PsiRequestBuilder} from '../../lib/psi';
+
+describe('PsiRequestBuilder', () => {
+  describe('#build', () => {
+    it('builds a correct request', () => {
+      const psiRequest = new PsiRequestBuilder(new URL('https://example.com'))
+          .addCategory('pwa')
+          .addCategory('performance')
+          .setStrategy('mobile')
+          .build();
+      const expectedUrl = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?' +
+          'url=https%3A%2F%2Fexample.com%2F&category=pwa&category=performance&strategy=mobile';
+      expect(psiRequest.url.toString()).toBe(expectedUrl);
+    });
+  });
+});

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "src/spec/**/*.ts"],  
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
- Adds a validator module that validates PWAs for the Trusted Web
  Activity quality criteria.
- The module uses the PageSpeed Insights API to run and collect
  Lighthouse scoring information.
- Adds a `validate` command to `@bubblewrap/cli`.
- Starts work on #104 