### PR TITLE
Improves packageId generation / validation

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -94,7 +94,6 @@ export async function build(
   }
 
   const twaManifest = await TwaManifest.fromFile('./twa-manifest.json');
-  twaManifest.validate();
 
   const passwords = await getPasswords(log);
 

--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -94,6 +94,8 @@ export async function build(
   }
 
   const twaManifest = await TwaManifest.fromFile('./twa-manifest.json');
+  twaManifest.validate();
+
   const passwords = await getPasswords(log);
 
   // Builds the Android Studio Project

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -92,9 +92,9 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
       message: 'Android Package Name (or Application ID):',
       default: twaManifest.packageId,
       validate: async (input): Promise<boolean> => {
-        if (!util.validatePackageId(input)) {
-          throw new Error('Invalid Application Id. Check requiements at ' +
-              'https://developer.android.com/studio/build/application-id');
+        const result = util.validatePackageId(input);
+        if (result !== null) {
+          throw new Error(result);
         }
         return true;
       },

--- a/packages/cli/src/lib/inputHelpers.ts
+++ b/packages/cli/src/lib/inputHelpers.ts
@@ -16,6 +16,7 @@
 
 import Color = require('color');
 import {isWebUri} from 'valid-url';
+import {util} from '@bubblewrap/core';
 
 const MIN_KEY_PASSWORD_LENGTH = 6;
 
@@ -27,10 +28,11 @@ export async function validateKeyPassword(input: string): Promise<boolean> {
 }
 
 export async function notEmpty(input: string, fieldName: string): Promise<boolean> {
-  if (input.trim().length > 0) {
-    return true;
+  const error = util.validateNotEmpty(input, fieldName);
+  if (error) {
+    throw new Error(error);
   }
-  throw new Error(`${fieldName} cannot be empty`);
+  return true;
 }
 
 export async function validateColor(color: string): Promise<boolean> {

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -222,9 +222,10 @@ export class TwaGenerator {
    * @param {Object} twaManifest configurations values for the project.
    */
   async createTwaProject(targetDirectory: string, twaManifest: TwaManifest): Promise<void> {
-    if (!twaManifest.validate()) {
-      throw new Error('Invalid TWA Manifest. Missing or incorrect fields.');
-    };
+    const error = twaManifest.validate();
+    if (error !== null) {
+      throw new Error(`Invalid TWA Manifest: ${error}`);
+    }
 
     this.log.info('Generating Android Project files:');
     const templateDirectory = path.join(__dirname, '../../template_project');

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -18,7 +18,7 @@
 
 import * as fs from 'fs';
 import fetch from 'node-fetch';
-import {findSuitableIcon, generatePackageId} from './util';
+import {findSuitableIcon, generatePackageId, validateNotEmpty} from './util';
 import Color = require('color');
 import Log from './Log';
 import {WebManifestIcon, WebManifestJson} from './types/WebManifest';
@@ -148,25 +148,36 @@ export class TwaManifest {
   /**
    * Validates if the Manifest has all the fields needed to generate a TWA project and if the
    * values for those fields are valid.
+   *
+   * @returns {string | null} the error, if any field has an error or null if all fields are valid.
    */
-  validate(): boolean {
-    if (!this.host) {
-      return false;
+  validate(): string | null {
+    let error;
+
+    error = validateNotEmpty(this.host, 'host');
+    if (error != null) {
+      return error;
     }
 
-    if (!this.name) {
-      return false;
+    error = validateNotEmpty(this.name, 'name');
+    if (error != null) {
+      return error;
     }
 
-    if (!this.startUrl) {
-      return false;
+    error = validateNotEmpty(this.startUrl, 'startUrl');
+    if (error != null) {
+      return error;
     }
 
     if (!this.iconUrl) {
-      return false;
+      return 'iconUrl cannot be empty';
     }
 
-    return true;
+    error = validateNotEmpty(this.iconUrl, 'iconUrl');
+    if (error != null) {
+      return error;
+    }
+    return error;
   }
 
   generateShortcuts(): string {
@@ -223,7 +234,7 @@ export class TwaManifest {
     }
 
     const twaManifest = new TwaManifest({
-      packageId: generatePackageId(webManifestUrl.host),
+      packageId: generatePackageId(webManifestUrl.host) || '',
       host: webManifestUrl.host,
       name: webManifest['name'] || webManifest['short_name'] || DEFAULT_APP_NAME,
       launcherName: webManifest['short_name'] ||

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -130,10 +130,41 @@ export function findSuitableIcon(
  *
  * @param {String} host the original hostname
  */
-export function generatePackageId(host: string): string {
+export function generatePackageId(host: string): string | null {
+  host = host.trim();
+  if (host.length === 0) {
+    return null;
+  }
+
   const parts = host.split('.').reverse();
-  parts.push('twa');
-  return parts.join('.').replace(DISALLOWED_ANDROID_PACKAGE_CHARS_REGEX, '_');
+  const packageId = [];
+  for (const part of parts) {
+    if (part.trim().length === 0) {
+      continue;
+    }
+    packageId.push(part);
+  }
+
+  if (packageId.length === 0) {
+    return null;
+  }
+
+  packageId.push('twa');
+  return packageId.join('.').replace(DISALLOWED_ANDROID_PACKAGE_CHARS_REGEX, '_');
+}
+
+/**
+ * Validates if a string is not null and not empty.
+ * @param input the string to be validated
+ * @param fieldName the field represented by the string
+ * @returns {string | null} a description of the error or null if no erro is found.
+ */
+export function validateNotEmpty(
+    input: string | null | undefined, fieldName: string): string | null {
+  if (input === null || input === undefined || input.trim().length <= 0) {
+    return `${fieldName} cannot be empty`;
+  }
+  return null;
 }
 
 /**
@@ -142,26 +173,29 @@ export function generatePackageId(host: string): string {
  *
  * Rules summary for the Package Id:
  * - It must have at least two segments (one or more dots).
- * - Each segment must start with a leter.
+ * - Each segment must start with a letter [a-zA-Z].
  * - All characters must be alphanumeric or an underscore [a-zA-Z0-9_].
  *
  * @param {string} input the package name to be validated
+ * @returns {string | null} a description of the error or null if no erro is found.
  */
-export function validatePackageId(input: string): boolean {
-  if (input.length <= 0) {
-    return false;
+export function validatePackageId(input: string): string | null{
+  const error = validateNotEmpty(input, 'packageId');
+  if (error !== null) {
+    return error;
   }
 
   const parts = input.split('.');
   if (parts.length < 2) {
-    return false;
+    return 'packageId must have at least 2 sections separated by "."';
   }
 
   for (const part of parts) {
     if (part.match(VALID_PACKAGE_ID_SEGMENT_REGEX) === null) {
-      return false;
+      return `Invalid packageId section: "${part}". Only alphanumeric characters and ` +
+          'underscore [a-zA-Z0-9_] are allowed in packageId sections. Each section must ' +
+          'start with a letter [a-zA-Z]';
     }
   }
-
-  return true;
+  return null;
 }

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -190,7 +190,7 @@ describe('TwaManifest', () => {
   describe('#validate', () => {
     it('Returns false for an empty TWA Manifest', () => {
       const twaManifest = new TwaManifest({} as TwaManifestJson);
-      expect(twaManifest.validate()).toBeFalse();
+      expect(twaManifest.validate()).not.toBeNull();
     });
 
     it('Returns true a correct TWA Manifest', () => {
@@ -213,7 +213,7 @@ describe('TwaManifest', () => {
         enableNotifications: true,
         shortcuts: [{name: 'name', url: '/', chosenIconUrl: 'icon.png'}],
       } as TwaManifestJson);
-      expect(twaManifest.validate()).toBeTrue();
+      expect(twaManifest.validate()).toBeNull();
     });
   });
 });

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -128,45 +128,77 @@ describe('util', () => {
   });
 
   describe('#generatePackageId', () => {
-    it('handles URL with multiple dashes', () => {
+    it('returns null for empty input', () => {
+      expect(util.generatePackageId('')).toBeNull();
+    });
+
+    it('returns null for input that generates an empty package', () => {
+      expect(util.generatePackageId('..')).toBeNull();
+    });
+
+    it('returns null for input that outputs packages with sectons starting with numbers', () => {
+      expect(util.generatePackageId('1pwadirectory')).toBe('1pwadirectory.twa');
+    });
+
+    it('handles input with multiple dashes', () => {
       const result = util.generatePackageId('pwa-directory-test.appspot.com');
       expect(result).toBe('com.appspot.pwa_directory_test.twa');
     });
-    it('handles URL with spaces', () => {
+
+    it('handles input with spaces', () => {
       const result = util.generatePackageId('pwa directory test.appspot.com');
       expect(result).toBe('com.appspot.pwa_directory_test.twa');
+    });
+
+    it('handles input that generates empty section', () => {
+      expect(util.generatePackageId('.pwadirectory')).toBe('pwadirectory.twa');
+      expect(util.generatePackageId('pwadirectory.')).toBe('pwadirectory.twa');
+      expect(util.generatePackageId('pwa..directory.')).toBe('directory.pwa.twa');
+    });
+  });
+
+  describe('#validateNotEmpty', () => {
+    it('throws Error for empty strings', async () => {
+      expect(util.validateNotEmpty('', 'Error')).not.toBeNull();
+      expect(util.validateNotEmpty('  ', 'Error')).not.toBeNull();
+      expect(util.validateNotEmpty(null, 'Error')).not.toBeNull();
+      expect(util.validateNotEmpty(undefined, 'Error')).not.toBeNull();
+    });
+
+    it('returns true for non-empty input', async () => {
+      expect(util.validateNotEmpty('a', 'Error')).toBeNull();
     });
   });
 
   describe('#validatePackageId', () => {
     it('returns true for valid packages', () => {
-      expect(util.validatePackageId('com.pwa_directory.appspot.com')).toBeTrue();
-      expect(util.validatePackageId('com.pwa1directory.appspot.com')).toBeTrue();
+      expect(util.validatePackageId('com.pwa_directory.appspot.com')).toBeNull();
+      expect(util.validatePackageId('com.pwa1directory.appspot.com')).toBeNull();
     });
 
     it('returns false for packages with invalid characters', () => {
-      expect(util.validatePackageId('com.pwa-directory.appspot.com')).toBeFalse();
-      expect(util.validatePackageId('com.pwa@directory.appspot.com')).toBeFalse();
-      expect(util.validatePackageId('com.pwa*directory.appspot.com')).toBeFalse();
-      expect(util.validatePackageId('com․pwa-directory.appspot.com')).toBeFalse();
+      expect(util.validatePackageId('com.pwa-directory.appspot.com')).not.toBeNull();
+      expect(util.validatePackageId('com.pwa@directory.appspot.com')).not.toBeNull();
+      expect(util.validatePackageId('com.pwa*directory.appspot.com')).not.toBeNull();
+      expect(util.validatePackageId('com․pwa-directory.appspot.com')).not.toBeNull();
     });
 
     it('returns false for packages empty sections', () => {
-      expect(util.validatePackageId('com.example.')).toBeFalse();
-      expect(util.validatePackageId('.com.example')).toBeFalse();
-      expect(util.validatePackageId('com..example')).toBeFalse();
+      expect(util.validatePackageId('com.example.')).not.toBeNull();
+      expect(util.validatePackageId('.com.example')).not.toBeNull();
+      expect(util.validatePackageId('com..example')).not.toBeNull();
     });
 
     it('packages with less than 2 sections return false', () => {
-      expect(util.validatePackageId('com')).toBeFalse();
-      expect(util.validatePackageId('')).toBeFalse();
+      expect(util.validatePackageId('com')).not.toBeNull();
+      expect(util.validatePackageId('')).not.toBeNull();
     });
 
     it('packages starting with non-letters return false', () => {
-      expect(util.validatePackageId('com.1char.twa')).toBeFalse();
-      expect(util.validatePackageId('1com.char.twa')).toBeFalse();
-      expect(util.validatePackageId('com.char.1twa')).toBeFalse();
-      expect(util.validatePackageId('_com.char.1twa')).toBeFalse();
+      expect(util.validatePackageId('com.1char.twa')).not.toBeNull();
+      expect(util.validatePackageId('1com.char.twa')).not.toBeNull();
+      expect(util.validatePackageId('com.char.1twa')).not.toBeNull();
+      expect(util.validatePackageId('_com.char.1twa')).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
- generatePackageId returns an error string  when a correct
  package cannot be generated from the input.
- validatePackageId returns an error string if the input is
  invalid or null if there's no error.
- validateNotEmpty introduced in `core`. `notEmpty()` in
  `cli/inputHelpers()` uses it.
- TwaGenerator#validate() changed to return an error string if the
  packageId is invalid or null if if it is valid. It also validates
  the packageId