### PR TITLE
Fix for CLI to work on latest Android CLI Tools

### DIFF
--- a/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
+++ b/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
@@ -66,7 +66,10 @@ export class AndroidSdkTools {
     await util.execInteractive(
         this.pathJoin(this.getAndroidHome(), '/tools/bin/sdkmanager'),
         ['--install',
-          `"build-tools;${BUILD_TOOLS_VERSION}"`],
+          `"build-tools;${BUILD_TOOLS_VERSION}"`,
+          // setting ANDROID_HOME via this.getEnv() should be enough, but version 6200805 of the
+          // the Android Command Line tools don't work properly if sdk_root is not set.
+          `--sdk_root="${this.getAndroidHome()}"`],
         env,
     );
   }

--- a/packages/core/src/spec/lib/androidSdk/AndroidSdkToolsSpec.ts
+++ b/packages/core/src/spec/lib/androidSdk/AndroidSdkToolsSpec.ts
@@ -91,11 +91,14 @@ describe('AndroidSdkTools', () => {
   describe('#installBuildTools', () => {
     const tests = [
       {platform: 'linux',
-        expectedAndroidHome: '/home/user/android-sdk/tools/bin/sdkmanager'},
+        expectedAndroidHome: '/home/user/android-sdk/',
+        expectedCwd: '/home/user/android-sdk/tools/bin/sdkmanager'},
       {platform: 'darwin',
-        expectedAndroidHome: '/home/user/android-sdk/tools/bin/sdkmanager'},
+        expectedAndroidHome: '/home/user/android-sdk/',
+        expectedCwd: '/home/user/android-sdk/tools/bin/sdkmanager'},
       {platform: 'win32',
-        expectedAndroidHome: 'C:\\Users\\user\\android-sdk\\tools\\bin\\sdkmanager'},
+        expectedAndroidHome: 'C:\\Users\\user\\android-sdk\\',
+        expectedCwd: 'C:\\Users\\user\\android-sdk\\tools\\bin\\sdkmanager'},
     ];
 
     tests.forEach((test) => {
@@ -107,8 +110,8 @@ describe('AndroidSdkTools', () => {
         spyOn(util, 'execInteractive').and.stub();
         androidSdkTools.installBuildTools();
         expect(util.execInteractive).toHaveBeenCalledWith(
-            test.expectedAndroidHome,
-            ['--install', '"build-tools;29.0.2"'],
+            test.expectedCwd,
+            ['--install', '"build-tools;29.0.2"', `--sdk_root="${test.expectedAndroidHome}"`],
             androidSdkTools.getEnv());
       });
     });


### PR DESCRIPTION
Setting ANDROID_HOME via should be enough for sdkmanager to work,
but version 6200805 of the the Android Command Line tools only work
if sdk_root is not set.