### PR TITLE
Improves AndroidSdkTools errors

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -86,7 +86,7 @@ export async function build(
   }
 
   const jdkHelper = new JdkHelper(process, config);
-  const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
+  const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper, log);
 
   if (!await androidSdkTools.checkBuildTools()) {
     console.log('Installing Android Build Tools. Please, read and accept the license agreement');


### PR DESCRIPTION
- throws error on constructor when then path to androidSdkTools doesn't exist
- throws error when installing build tools and path to sdkmanager doesn't exist