### PR TITLE
CLI checks minimum supported Node.js version

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -50,6 +50,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
       "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
     },
+    "@types/semver": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
+      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/through": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
@@ -301,6 +309,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,11 +30,13 @@
     "@types/color": "^3.0.0",
     "@types/inquirer": "^6.5.0",
     "@types/minimist": "^1.2.0",
+    "@types/semver": "^7.1.0",
     "@types/valid-url": "^1.0.2",
     "color": "^3.1.2",
     "colors": "^1.4.0",
     "inquirer": "^7.0.4",
     "minimist": "^1.2.2",
+    "semver": "^7.3.2",
     "valid-url": "^1.0.9"
   }
 }

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -27,7 +27,7 @@ export class Cli {
   async run(args: string[]): Promise<boolean> {
     if (major(process.versions.node) < 10) {
       throw new Error(`Current Node.js version is ${process.versions.node}.` +
-          'Node.js version 10 or above is required to run bubblewrap');
+          ' Node.js version 10 or above is required to run bubblewrap');
     }
     const config = await loadOrCreateConfig();
 

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -27,7 +27,7 @@ export class Cli {
   async run(args: string[]): Promise<boolean> {
     if (major(process.versions.node) < 10) {
       throw new Error(`Current Node.js version is ${process.versions.node}.` +
-          ' Node.js version 10 or above is required to run bubblewrap');
+          ' Node.js version 10 or above is required to run bubblewrap.');
     }
     const config = await loadOrCreateConfig();
 

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -21,9 +21,14 @@ import {build} from './cmds/build';
 import {init} from './cmds/init';
 import {validate} from './cmds/validate';
 import {loadOrCreateConfig} from './config';
+import {major} from 'semver';
 
 export class Cli {
   async run(args: string[]): Promise<boolean> {
+    if (major(process.versions.node) < 10) {
+      throw new Error(`Current Node.js version is ${process.versions.node}.` +
+          'Node.js version 10 or above is required to run bubblewrap');
+    }
     const config = await loadOrCreateConfig();
 
     const parsedArgs = minimist(args);


### PR DESCRIPTION
Uses `semver` to check the Node.js version and throws an error if an unsupported version is used.

![Capture](https://user-images.githubusercontent.com/1733592/81113365-0428ef00-8f18-11ea-903b-120d717a9238.PNG)


Closes #152