### PR TITLE
Updates android-browser-helper version

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -166,5 +166,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.2.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.0'
 }


### PR DESCRIPTION
- Updates to use android-browser-helper 1.3.0, so apps generated
  with Bubblewrap get the bug fixes.