### PR TITLE
Prevent build failing when PSI fails

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -111,10 +111,16 @@ export async function build(
 
   if (!args.skipPwaValidation) {
     log.info('Checking PWA Quality Criteria...');
-    const pwaValidationResult = (await pwaValidationPromise)!;
-    printValidationResult(pwaValidationResult, log);
-    if (pwaValidationResult.status === 'FAIL') {
-      log.warn('PWA Quality Criteria check failed.');
+    try {
+      const pwaValidationResult = (await pwaValidationPromise)!;
+      printValidationResult(pwaValidationResult, log);
+      if (pwaValidationResult.status === 'FAIL') {
+        log.warn('PWA Quality Criteria check failed.');
+      }
+    } catch (e) {
+      const message = 'Failed to run the PWA Quality Criteria checks. Skipping.';
+      log.debug(e);
+      log.warn(message);
     }
   }
 

--- a/packages/cli/src/lib/cmds/install.ts
+++ b/packages/cli/src/lib/cmds/install.ts
@@ -21,6 +21,8 @@ const APK_FILE_PARAM = '--apkFile';
 const VERBOSE_PARAM = '--verbose';
 const DEFAULT_APK_FILE = './app-release-signed.apk';
 
+const PARAMETERS_TO_IGNORE = ['--verbose', '-r'];
+
 export async function install(
     args: ParsedArgs, config: Config, log = new Log('install')): Promise<boolean> {
   const jdkHelper = new JdkHelper(process, config);
@@ -34,7 +36,7 @@ export async function install(
   // 2. So, we want to start collecting args from parameter 3 and ignore any a possible
   // `--apkFile`, which is specific to install. Extra parameters are passed through to `adb`.
   const originalArgs = process.argv.slice(3).filter(
-      (v) => !v.startsWith(APK_FILE_PARAM) && !v.startsWith(VERBOSE_PARAM));
+      (v) => !v.startsWith(APK_FILE_PARAM) && PARAMETERS_TO_IGNORE.indexOf(v) < 0);
   await androidSdkTools.install(apkFile, originalArgs);
   return true;
 }

--- a/packages/cli/src/lib/cmds/install.ts
+++ b/packages/cli/src/lib/cmds/install.ts
@@ -18,7 +18,6 @@ import {AndroidSdkTools, Config, JdkHelper, Log} from '@bubblewrap/core';
 import {ParsedArgs} from 'minimist';
 
 const APK_FILE_PARAM = '--apkFile';
-const VERBOSE_PARAM = '--verbose';
 const DEFAULT_APK_FILE = './app-release-signed.apk';
 
 const PARAMETERS_TO_IGNORE = ['--verbose', '-r'];

--- a/packages/core/src/lib/Log.ts
+++ b/packages/core/src/lib/Log.ts
@@ -76,9 +76,9 @@ export default class Log {
    * @param args extra arguments for the console.
    */
   error(message: string, ...args: string[]): void {
-    this.output.log('\n');
+    this.output.error('\n');
     this.log(this.output.error, this.red('ERROR ' + message), ...args);
-    this.output.log('\n');
+    this.output.error('\n');
   }
 
   /**

--- a/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
+++ b/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
@@ -172,8 +172,9 @@ export class AndroidSdkTools {
     const env = this.getEnv();
     const installCmd = [
       `"${this.pathJoin(this.getAndroidHome(), '/platform-tools/adb')}"`,
-      ...passthroughArgs,
       'install',
+      '-r', // Replace app if another with the same package id already installed.
+      ...passthroughArgs,
       apkFilePath,
     ];
     await util.execute(installCmd, env, this.log);

--- a/packages/core/src/spec/lib/androidSdk/AndroidSdkToolsSpec.ts
+++ b/packages/core/src/spec/lib/androidSdk/AndroidSdkToolsSpec.ts
@@ -154,18 +154,21 @@ describe('AndroidSdkTools', () => {
         expectedCwd: [
           '"/home/user/android-sdk/platform-tools/adb"',
           'install',
+          '-r',
           'app-release-signed.apk',
         ]},
       {platform: 'darwin',
         expectedCwd: [
           '"/home/user/android-sdk/platform-tools/adb"',
           'install',
+          '-r',
           'app-release-signed.apk',
         ]},
       {platform: 'win32',
         expectedCwd: [
           '"C:\\Users\\user\\android-sdk\\platform-tools\\adb"',
           'install',
+          '-r',
           'app-release-signed.apk',
         ]},
     ];

--- a/packages/validator/src/lib/PwaValidator.ts
+++ b/packages/validator/src/lib/PwaValidator.ts
@@ -62,7 +62,13 @@ export class PwaValidator {
         .setStrategy('mobile')
         .build();
 
-    const psiResult = await this.psi.runPageSpeedInsights(psiRequest);
+    let psiResult;
+    try {
+      psiResult = await this.psi.runPageSpeedInsights(psiRequest);
+    } catch (e) {
+      throw new Error('Error calling the PageSpeed Insights API: ' + e);
+    }
+
     const pwaScore = psiResult.lighthouseResult.categories.pwa.score;
     const performanceScore = psiResult.lighthouseResult.categories.performance.score;
     if (pwaScore === null || performanceScore === null || isNaN(pwaScore) ||


### PR DESCRIPTION
- When the PSI request fails, show an error message but don't fail
  the entire build.

- Appends `-r` to the APK install command to remove an existing app
  with the same packageId and reinstall it.