### PR TITLE
Generates assetlinks.json when building the App

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
-import {AndroidSdkTools, Config, DigitalAssetLinks, GradleWrapper, JdkHelper, Log, TwaManifest,
-  KeyTool} from '@bubblewrap/core';
+import {AndroidSdkTools, Config, DigitalAssetLinks, GradleWrapper, JdkHelper, KeyTool, Log,
+  TwaManifest} from '@bubblewrap/core';
 import * as inquirer from 'inquirer';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -79,6 +79,36 @@ async function startValidation(): Promise<PwaValidationResult> {
   return PwaValidator.validate(new URL(twaManifest.startUrl, twaManifest.webManifestUrl));
 }
 
+async function generateAssetLinks(keyTool: KeyTool, twaManifest: TwaManifest,
+    passwords: SigningKeyPasswords, log: Log): Promise<void> {
+  try {
+    const digitalAssetLinksFile = './assetlinks.json';
+    const keyInfo = await keyTool.keyInfo({
+      path: twaManifest.signingKey.path,
+      alias: twaManifest.signingKey.alias,
+      keypassword: passwords.keyPassword,
+      password: passwords.keystorePassword,
+    });
+
+    const sha256Fingerprint = keyInfo.fingerprints.get('SHA256');
+    if (!sha256Fingerprint) {
+      log.warn('Could not find SHA256 fingerprint. Skipping generating "assetlinks.json"');
+      return;
+    }
+
+    const digitalAssetLinks =
+    DigitalAssetLinks.generateAssetLinks(twaManifest.packageId, sha256Fingerprint);
+
+    await fs.promises.writeFile(digitalAssetLinksFile, digitalAssetLinks);
+
+    log.info(`Digital Asset Links file generated at ${digitalAssetLinksFile}`);
+    log.info('Read more about setting up Digital Asset Links at https://developers.google.com' +
+        '/web/android/trusted-web-activity/quick-start#creating-your-asset-link-file');
+  } catch (e) {
+    log.warn('Error generating "assetlinks.json"', e);
+  }
+}
+
 export async function build(
     config: Config, args: ParsedArgs, log = new Log('build')): Promise<boolean> {
   let pwaValidationPromise;
@@ -140,30 +170,6 @@ export async function build(
 
   log.info(`Signed Android App generated at "${outputFile}"`);
 
-  try {
-    const digitalAssetLinksFile = './assetlinks.json';
-    const keyInfo = await keyTool.keyInfo({
-      path: twaManifest.signingKey.path,
-      alias: twaManifest.signingKey.alias,
-      keypassword: passwords.keyPassword,
-      password: passwords.keystorePassword,
-    });
-
-    const sha256Fingerprint = keyInfo.fingerprints.get('SHA256');
-    if (!sha256Fingerprint) {
-      log.warn('Could not find SHA256 fingerprint. Skipping generating "assetlinks.json"');
-    } else {
-      const digitalAssetLinks =
-      DigitalAssetLinks.generateAssetLinks(twaManifest.packageId, sha256Fingerprint);
-
-      await fs.promises.writeFile(digitalAssetLinksFile, digitalAssetLinks);
-
-      log.info(`Digital Asset Links file generated at ${digitalAssetLinksFile}`);
-      log.warn('If opting into "App Signing by Google Play" when uploading the Android app for ' +
-          'the first time, the SHA-256 fingerprint will differ.');
-    }
-  } catch (e) {
-    log.warn('Error generating "assetlinks.json"', e);
-  }
+  await generateAssetLinks(keyTool, twaManifest, passwords, log);
   return true;
 }

--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -97,7 +97,7 @@ async function generateAssetLinks(keyTool: KeyTool, twaManifest: TwaManifest,
     }
 
     const digitalAssetLinks =
-    DigitalAssetLinks.generateAssetLinks(twaManifest.packageId, sha256Fingerprint);
+      DigitalAssetLinks.generateAssetLinks(twaManifest.packageId, sha256Fingerprint);
 
     await fs.promises.writeFile(digitalAssetLinksFile, digitalAssetLinks);
 

--- a/packages/core/src/lib/DigitalAssetLinks.ts
+++ b/packages/core/src/lib/DigitalAssetLinks.ts
@@ -14,25 +14,12 @@
  *  limitations under the License.
  */
 
-import {AndroidSdkTools} from './lib/androidSdk/AndroidSdkTools';
-import {Config} from './lib/Config';
-import {GradleWrapper} from './lib/GradleWrapper';
-import Log from './lib/Log';
-import {JdkHelper} from './lib/jdk/JdkHelper';
-import {KeyTool} from './lib/jdk/KeyTool';
-import {TwaManifest} from './lib/TwaManifest';
-import {TwaGenerator} from './lib/TwaGenerator';
-import {DigitalAssetLinks} from './lib/DigitalAssetLinks';
-import * as util from './lib/util';
-
-export {AndroidSdkTools,
-  Config,
-  DigitalAssetLinks,
-  GradleWrapper,
-  JdkHelper,
-  KeyTool,
-  Log,
-  TwaGenerator,
-  TwaManifest,
-  util,
-};
+export class DigitalAssetLinks {
+  static generateAssetLinks(applicationId: string, sha256Fingerprint: string): string {
+    return `[{
+      "relation": ["delegate_permission/common.handle_all_urls"],
+      "target" : { "namespace": "android_app", "package_name": "${applicationId}",
+                   "sha256_cert_fingerprints": ["${sha256Fingerprint}"] }
+    }]\n`;
+  }
+}

--- a/packages/core/src/spec/lib/DigitalAssetLinksSpec.ts
+++ b/packages/core/src/spec/lib/DigitalAssetLinksSpec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {DigitalAssetLinks} from '../../lib/DigitalAssetLinks';
+
+describe('DigitalAssetLinks', () => {
+  describe('#generateAssetLinks', () => {
+    it('Generates the assetlinks markup', () => {
+      const packageName = 'com.test.twa';
+      const fingerprint = 'FINGERPRINT';
+      const digitalAssetLinks =
+        JSON.parse(DigitalAssetLinks.generateAssetLinks(packageName, fingerprint));
+      expect(digitalAssetLinks.length).toBe(1);
+      expect(digitalAssetLinks[0].relation.length).toBe(1);
+      expect(digitalAssetLinks[0].relation[0]).toBe('delegate_permission/common.handle_all_urls');
+      expect(digitalAssetLinks[0].target.namespace).toBe('android_app');
+      expect(digitalAssetLinks[0].target.package_name).toBe(packageName);
+      expect(digitalAssetLinks[0].target.sha256_cert_fingerprints.length).toBe(1);
+      expect(digitalAssetLinks[0].target.sha256_cert_fingerprints[0]).toBe(fingerprint);
+    });
+  });
+});


### PR DESCRIPTION
- Uses information from they keystore and the applicationId to
  generate the Digital Asset Links file that matches the key used
  to build the signed APK.

- If the developer opted into Play Signing by Play the fingerprint
  won't match and the Digital Asset Links validation will not
  validate

Closes #5 