### PR TITLE
Runs `apksigner.jar` instead of `apksigner.bat` on win32

### DIFF
--- a/packages/core/src/lib/jdk/JdkHelper.ts
+++ b/packages/core/src/lib/jdk/JdkHelper.ts
@@ -18,6 +18,7 @@
 
 import {Config} from '../Config';
 import * as path from 'path';
+import {execute} from '../util';
 
 /**
  * Helps getting information relevant to the JDK installed, including
@@ -48,6 +49,18 @@ export class JdkHelper {
       this.pathSeparator = ':';
       this.pathEnvironmentKey = 'PATH';
     }
+  }
+
+  /**
+   * Runs the `java` command, passing args as parameters.
+   */
+  async runJava(args: string[]): Promise<{stdout: string; stderr: string}> {
+    const java = this.process.platform === 'win32' ? '/bin/java.exe' : '/bin/java';
+    const runJavaCmd = [
+      `"${this.joinPath(this.getJavaHome(), java)}"`,
+    ];
+    runJavaCmd.push(...args);
+    return await execute(runJavaCmd, this.getEnv());
   }
 
   /**


### PR DESCRIPTION
- apksigner.bat depends on find_java.bat, which is broken in the
  Android CLI tools.
- This implements a workaround that runs `apksigner.jar` directly.