### PR TITLE
Requires minimum size for app shortcut icons

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -29,6 +29,9 @@ const MIN_ICON_SIZE = 512;
 // As described on https://developer.chrome.com/apps/manifest/name#short_name
 const SHORT_NAME_MAX_SIZE = 12;
 
+// The minimum size needed for the shortcut icon
+const MIN_SHORTCUT_ICON_SIZE = 96;
+
 // Default values used on the Twa Manifest
 const DEFAULT_SPLASHSCREEN_FADEOUT_DURATION = 300;
 const DEFAULT_APP_NAME = 'My TWA';
@@ -214,7 +217,7 @@ export class TwaManifest {
         continue;
       }
 
-      const suitableIcon = findSuitableIcon(s.icons, 'any');
+      const suitableIcon = findSuitableIcon(s.icons, 'any', MIN_SHORTCUT_ICON_SIZE);
       if (!suitableIcon) {
         TwaManifest.log.warn(`Skipping shortcut[${i}] for not finding a suitable icon.`);
         continue;

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -41,6 +41,7 @@ describe('TwaManifest', () => {
           'url': '/launch',
           'icons': [{
             'src': '/shortcut_icon.png',
+            'sizes': '96x96',
           }],
         }],
       };
@@ -108,6 +109,25 @@ describe('TwaManifest', () => {
       const twaManifest = TwaManifest.fromWebManifestJson(manifestUrl, manifest);
       expect(twaManifest.name).toBe('PWA Directory');
       expect(twaManifest.launcherName).toBe('PWA Director');
+    });
+
+    it('Ignores shortcuts if icon size is empty or too small', () => {
+      const manifest = {
+        'shortcuts': [{
+          'name': 'invalid',
+          'url': '/invalid',
+          'icons': [{
+            'src': '/no_size.png',
+          }, {
+            'src': '/small_size.png',
+            'sizes': '95x95',
+          }],
+        }],
+      };
+      const manifestUrl = new URL('https://pwa-directory.com/manifest.json');
+      const twaManifest = TwaManifest.fromWebManifestJson(manifestUrl, manifest);
+      expect(twaManifest.shortcuts).toEqual([]);
+      expect(twaManifest.generateShortcuts()).toBe('[]');
     });
   });
 


### PR DESCRIPTION
As a quality measure, app shortcut icons must be at least half of the device's ideal size on Android, which is 48dp.

[Devtools](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2224796 ) and [documentation](https://web.dev/app-shortcuts/#icons-(optional)) have been updated. Let's now update bubblewrap as well ;)

@andreban @rayankans 