### PR TITLE
Closes #180: Use monochrome icon for notifications

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -76,16 +76,20 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
     }, {
       name: 'maskableIconUrl',
       type: 'input',
-      message: 'URL to an image that is at least 512x512px to be used when generating ' +
-          'maskable icons',
+      message:
+        'URL to an image that is at least 512x512px to be used when generating maskable icons.' +
+        '\n\nMaskable icons should look good when their edges are removed by an icon mask. ' +
+        'They will be used to display adaptive launcher icons on the Android home screen.',
       default: twaManifest.maskableIconUrl,
       filter: (input): string | undefined => input.length === 0 ? undefined : input,
       validate: async (input): Promise<boolean> => input === undefined || await validateUrl(input),
     }, {
       name: 'monochromeIconUrl',
       type: 'input',
-      message: 'URL to an image that is at least 48x48px to be used when generating ' +
-          'monochrome icons',
+      message:
+        'URL to an image that is at least 48x48px to be used when generating monochrome icons.' +
+        '\n\nMonochrome icons should look good when displayed with a single color,' +
+        'the PWA\' theme_color. They will be used for notification icons.',
       default: twaManifest.monochromeIconUrl,
       filter: (input): string | undefined => input.length === 0 ? undefined : input,
       validate: async (input): Promise<boolean> => input === undefined || await validateUrl(input),

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -82,6 +82,14 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
       filter: (input): string | undefined => input.length === 0 ? undefined : input,
       validate: async (input): Promise<boolean> => input === undefined || await validateUrl(input),
     }, {
+      name: 'monochromeIconUrl',
+      type: 'input',
+      message: 'URL to an image that is at least 48x48px to be used when generating ' +
+          'monochrome icons',
+      default: twaManifest.monochromeIconUrl,
+      filter: (input): string | undefined => input.length === 0 ? undefined : input,
+      validate: async (input): Promise<boolean> => input === undefined || await validateUrl(input),
+    }, {
       name: 'shortcuts',
       type: 'confirm',
       message: 'Include app shortcuts?\n' + JSON.stringify(twaManifest.shortcuts, null, 2),
@@ -124,6 +132,7 @@ async function confirmTwaConfig(twaManifest: TwaManifest): Promise<TwaManifest> 
   twaManifest.startUrl = result.startUrl;
   twaManifest.iconUrl = result.iconUrl;
   twaManifest.maskableIconUrl = result.maskableIconUrl;
+  twaManifest.monochromeIconUrl = result.monochromeIconUrl;
   twaManifest.shortcuts = result.shortcuts ? twaManifest.shortcuts : [];
   twaManifest.packageId = result.packageId;
   twaManifest.signingKey = {

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -76,6 +76,14 @@ const SHORTCUT_IMAGES: IconDefinition[] = [
   {dest: 'app/src/main/res/drawable-xxxhdpi/', size: 192},
 ];
 
+const NOTIFICATION_IMAGES: IconDefinition[] = [
+  {dest: 'app/src/main/res/drawable-mdpi/ic_notification_icon.png', size: 24},
+  {dest: 'app/src/main/res/drawable-hdpi/ic_notification_icon.png', size: 36},
+  {dest: 'app/src/main/res/drawable-xhdpi/ic_notification_icon.png', size: 48},
+  {dest: 'app/src/main/res/drawable-xxhdpi/ic_notification_icon.png', size: 72},
+  {dest: 'app/src/main/res/drawable-xxxhdpi/ic_notification_icon.png', size: 96},
+];
+
 const WEB_MANIFEST_LOCATION = '/app/src/main/res/raw/';
 const WEB_MANIFEST_FILE_NAME = 'web_app_manifest.json';
 
@@ -254,6 +262,11 @@ export class TwaGenerator {
     // Generate adaptive images
     if (twaManifest.maskableIconUrl) {
       await this.generateIcons(twaManifest.maskableIconUrl, targetDirectory, ADAPTIVE_IMAGES);
+    }
+
+    // Generate notification images
+    if (twaManifest.monochromeIconUrl) {
+      await this.generateIcons(twaManifest.monochromeIconUrl, targetDirectory, NOTIFICATION_IMAGES);
     }
 
     if (twaManifest.webManifestUrl) {

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -32,6 +32,9 @@ const SHORT_NAME_MAX_SIZE = 12;
 // The minimum size needed for the shortcut icon
 const MIN_SHORTCUT_ICON_SIZE = 96;
 
+// The minimum size needed for the notification icon
+const MIN_NOTIFICATION_ICON_SIZE = 48;
+
 // Default values used on the Twa Manifest
 const DEFAULT_SPLASHSCREEN_FADEOUT_DURATION = 300;
 const DEFAULT_APP_NAME = 'My TWA';
@@ -98,6 +101,7 @@ export class TwaManifest {
   startUrl: string;
   iconUrl: string | undefined;
   maskableIconUrl: string | undefined;
+  monochromeIconUrl: string | undefined;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
   appVersionCode: number;
@@ -121,6 +125,7 @@ export class TwaManifest {
     this.startUrl = data.startUrl;
     this.iconUrl = data.iconUrl;
     this.maskableIconUrl = data.maskableIconUrl;
+    this.monochromeIconUrl = data.monochromeIconUrl;
     this.splashScreenFadeOutDuration = data.splashScreenFadeOutDuration;
     this.signingKey = data.signingKey;
     this.appVersionName = data.appVersion;
@@ -205,6 +210,9 @@ export class TwaManifest {
     const maskableIcon: WebManifestIcon | null = webManifest.icons ?
       findSuitableIcon(webManifest.icons, 'maskable', MIN_ICON_SIZE) : null;
 
+    const monochromeIcon: WebManifestIcon | null = webManifest.icons ?
+      findSuitableIcon(webManifest.icons, 'monochrome', MIN_NOTIFICATION_ICON_SIZE) : null;
+
     const fullStartUrl: URL = new URL(webManifest['start_url'] || '/', webManifestUrl);
 
     const shortcuts: ShortcutInfo[] = [];
@@ -236,19 +244,23 @@ export class TwaManifest {
       }
     }
 
+    function resolveIconUrl(icon: WebManifestIcon | null): string | undefined {
+      return icon ? new URL(icon.src, webManifestUrl).toString() : undefined;
+    }
+
     const twaManifest = new TwaManifest({
       packageId: generatePackageId(webManifestUrl.host) || '',
       host: webManifestUrl.host,
       name: webManifest['name'] || webManifest['short_name'] || DEFAULT_APP_NAME,
       launcherName: webManifest['short_name'] ||
-          webManifest['name']?.substring(0, SHORT_NAME_MAX_SIZE) || DEFAULT_APP_NAME,
+        webManifest['name']?.substring(0, SHORT_NAME_MAX_SIZE) || DEFAULT_APP_NAME,
       themeColor: webManifest['theme_color'] || DEFAULT_THEME_COLOR,
       navigationColor: DEFAULT_NAVIGATION_COLOR,
       backgroundColor: webManifest['background_color'] || DEFAULT_BACKGROUND_COLOR,
       startUrl: fullStartUrl.pathname + fullStartUrl.search,
-      iconUrl: icon ? new URL(icon.src, webManifestUrl).toString() : undefined,
-      maskableIconUrl:
-         maskableIcon ? new URL(maskableIcon.src, webManifestUrl).toString() : undefined,
+      iconUrl: resolveIconUrl(icon),
+      maskableIconUrl: resolveIconUrl(maskableIcon),
+      monochromeIconUrl: resolveIconUrl(monochromeIcon),
       appVersion: DEFAULT_APP_VERSION_NAME,
       signingKey: {
         path: DEFAULT_SIGNING_KEY_PATH,
@@ -301,6 +313,7 @@ export interface TwaManifestJson {
   startUrl: string;
   iconUrl?: string;
   maskableIconUrl?: string;
+  monochromeIconUrl?: string;
   splashScreenFadeOutDuration: number;
   signingKey: SigningKeyInfo;
   appVersionCode?: number; // Older Manifests may not have this field.

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -131,6 +131,40 @@ describe('TwaManifest', () => {
       expect(twaManifest.shortcuts).toEqual([]);
       expect(twaManifest.generateShortcuts()).toBe('[]');
     });
+
+    it('resolves URLs for maskable and monochrome icons', () => {
+      const manifest = {
+        'name': 'PWA Directory',
+        'short_name': 'PwaDirectory',
+        'start_url': '/?utm_source=homescreen',
+        'icons': [{
+          'src': '/favicons/any.png',
+          'sizes': '512x512',
+          'type': 'image/png',
+          'purpose': 'any',
+        }, {
+          'src': '/favicons/maskable.png',
+          'sizes': '512x512',
+          'type': 'image/png',
+          'purpose': 'maskable',
+        }, {
+          'src': '/favicons/monochrome.png',
+          'sizes': '512x512',
+          'type': 'image/png',
+          'purpose': 'monochrome',
+        }],
+      };
+      const manifestUrl = new URL('https://pwa-directory.com/manifest.json');
+      const twaManifest = TwaManifest.fromWebManifestJson(manifestUrl, manifest);
+      expect(twaManifest.packageId).toBe('com.pwa_directory.twa');
+      expect(twaManifest.name).toBe('PWA Directory');
+      expect(twaManifest.launcherName).toBe('PwaDirectory');
+      expect(twaManifest.startUrl).toBe('/?utm_source=homescreen');
+      expect(twaManifest.iconUrl)
+          .toBe('https://pwa-directory.com/favicons/any.png');
+      expect(twaManifest.maskableIconUrl).toBe('https://pwa-directory.com/favicons/maskable.png');
+      expect(twaManifest.monochromeIconUrl).toBe('https://pwa-directory.com/favicons/monochrome.png');
+    });
   });
 
   describe('#constructor', () => {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -54,6 +54,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.iconUrl)
           .toBe('https://pwa-directory.com/favicons/android-chrome-512x512.png');
       expect(twaManifest.maskableIconUrl).toBeUndefined();
+      expect(twaManifest.monochromeIconUrl).toBeUndefined();
       expect(twaManifest.themeColor.hex()).toBe('#00FF00');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#7CC0FF');
@@ -87,6 +88,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.startUrl).toBe('/');
       expect(twaManifest.iconUrl).toBeUndefined();
       expect(twaManifest.maskableIconUrl).toBeUndefined();
+      expect(twaManifest.monochromeIconUrl).toBeUndefined();
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#FFFFFF');

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
 
         <meta-data
             android:name="twa_generator"
-            android:value="@string/generatorApp" />            
+            android:value="@string/generatorApp" />
 
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
             android:label="@string/launcherName">
@@ -107,14 +107,20 @@
         </provider>
 
         <service
-             android:name="com.google.androidbrowserhelper.trusted.DelegationService"
-             android:enabled="@bool/enableNotification"
-             android:exported="@bool/enableNotification">
+            android:name="com.google.androidbrowserhelper.trusted.DelegationService"
+            android:enabled="@bool/enableNotification"
+            android:exported="@bool/enableNotification">
 
-             <intent-filter>
-                 <action android:name="android.support.customtabs.trusted.TRUSTED_WEB_ACTIVITY_SERVICE"/>
-                 <category android:name="android.intent.category.DEFAULT"/>
-             </intent-filter>
+            <% if (monochromeIconUrl) { %>
+                <meta-data
+                    android:name="android.support.customtabs.trusted.SMALL_ICON"
+                    android:value="@drawable/ic_notification_icon" />
+            <% } %>
+
+            <intent-filter>
+                <action android:name="android.support.customtabs.trusted.TRUSTED_WEB_ACTIVITY_SERVICE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
          </service>
 
     </application>


### PR DESCRIPTION
Adds `monochromeIconUrl` following the same format as the generic & maskable icons. Android deals with transforming notification images so no additional work is needed to follow the spec! Additionally fixed up some indentation.