### PR TITLE
Fixes Unhandled Promise Rejections

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -44,7 +44,7 @@ export class Cli {
         command = 'help';
       }
     } else {
-      command = parsedArgs._[0];
+      command = parsedArgs._[0] || 'help';
     }
 
     switch (command) {

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -44,7 +44,12 @@ export class Cli {
         command = 'help';
       }
     } else {
-      command = parsedArgs._[0] || 'help';
+      command = parsedArgs._[0];
+    }
+
+    // If no command is given, default to 'help'.
+    if (!command) {
+      command = 'help';
     }
 
     switch (command) {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -22,7 +22,7 @@ import * as inquirer from 'inquirer';
 import {existsSync} from 'fs';
 import {promises as fsPromises} from 'fs';
 
-const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap-config');
+const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap');
 const DEFAULT_CONFIG_NAME = 'bubblewrap-config.json';
 const DEFAULT_CONFIG_FILE_PATH = join(DEFAULT_CONFIG_FOLDER, DEFAULT_CONFIG_NAME);
 const LEGACY_CONFIG_FOLDER = join(homedir(), '.llama-pack');
@@ -58,14 +58,14 @@ async function renameConfigIfNeeded(log = new Log('config')): Promise<void> {
     await fsPromises.mkdir(DEFAULT_CONFIG_FOLDER);
     await fsPromises.rename(LEGACY_CONFIG_FILE_PATH, DEFAULT_CONFIG_FILE_PATH);
   } else {
-    fsPromises.rename(LEGACY_CONFIG_FOLDER, DEFAULT_CONFIG_FOLDER);
-    fsPromises.rename(join(DEFAULT_CONFIG_FOLDER, LEGACY_CONFIG_NAME), DEFAULT_CONFIG_FILE_PATH);
+    await fsPromises.rename(LEGACY_CONFIG_FOLDER, DEFAULT_CONFIG_FOLDER);
+    await fsPromises
+        .rename(join(DEFAULT_CONFIG_FOLDER, LEGACY_CONFIG_NAME), DEFAULT_CONFIG_FILE_PATH);
   }
 }
 
 
-export async function loadOrCreateConfig(path =
-join(DEFAULT_CONFIG_FOLDER, DEFAULT_CONFIG_NAME)): Promise<Config> {
+export async function loadOrCreateConfig(path = DEFAULT_CONFIG_FILE_PATH): Promise<Config> {
   await renameConfigIfNeeded();
   const existingConfig = await Config.loadConfig(path);
   if (existingConfig) return existingConfig;

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -23,7 +23,7 @@ import {existsSync} from 'fs';
 import {promises as fsPromises} from 'fs';
 
 const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap');
-const DEFAULT_CONFIG_NAME = 'bubblewrap-config.json';
+const DEFAULT_CONFIG_NAME = 'config.json';
 const DEFAULT_CONFIG_FILE_PATH = join(DEFAULT_CONFIG_FOLDER, DEFAULT_CONFIG_NAME);
 const LEGACY_CONFIG_FOLDER = join(homedir(), '.llama-pack');
 const LEGACY_CONFIG_NAME = 'llama-pack-config.json';

--- a/packages/cli/src/spec/configSpec.ts
+++ b/packages/cli/src/spec/configSpec.ts
@@ -23,7 +23,7 @@ import * as mock from 'mock-fs';
 import * as inquirer from 'inquirer';
 
 const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap');
-const DEFAULT_CONFIG_NAME = 'bubblewrap-config.json';
+const DEFAULT_CONFIG_NAME = 'config.json';
 const DEFAULT_CONFIG_FILE_PATH = join(DEFAULT_CONFIG_FOLDER, DEFAULT_CONFIG_NAME);
 const LEGACY_CONFIG_FOLDER = join(homedir(), '.llama-pack');
 const LEGACY_CONFIG_NAME = 'llama-pack-config.json';
@@ -91,7 +91,7 @@ describe('config', () => {
               'llama-pack-config.json': '{"content":"some old content"}',
             },
             [DEFAULT_CONFIG_FOLDER]: {
-              'bubblewrap-config.json': '{"content":"some new content"}',
+              'config.json': '{"content":"some new content"}',
             }});
           await loadOrCreateConfig();
           // Checks if both of the files exists.

--- a/packages/cli/src/spec/configSpec.ts
+++ b/packages/cli/src/spec/configSpec.ts
@@ -22,7 +22,7 @@ import {loadOrCreateConfig} from '../lib/config';
 import * as mock from 'mock-fs';
 import * as inquirer from 'inquirer';
 
-const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap-config');
+const DEFAULT_CONFIG_FOLDER = join(homedir(), '.bubblewrap');
 const DEFAULT_CONFIG_NAME = 'bubblewrap-config.json';
 const DEFAULT_CONFIG_FILE_PATH = join(DEFAULT_CONFIG_FOLDER, DEFAULT_CONFIG_NAME);
 const LEGACY_CONFIG_FOLDER = join(homedir(), '.llama-pack');
@@ -41,7 +41,7 @@ beforeAll(() => {
 describe('config', () => {
   describe('#loadOrCreateConfig', () => {
     it('checks if the file\'s name was changed in case it has the old name', async () => {
-      // Creates a mock file systes.
+      // Creates a mock file system.
       mock({
         [LEGACY_CONFIG_FOLDER]: {
           'llama-pack-config.json': '{}',
@@ -83,8 +83,8 @@ describe('config', () => {
       mock.restore();
     });
 
-    it('checks if both of the files exists in case there are old and new config files'
-        , async () => {
+    it('checks if both of the files exists in case there are old and new config files',
+        async () => {
           // Creates a mock file systes.
           mock({
             [LEGACY_CONFIG_FOLDER]: {


### PR DESCRIPTION
- Added missing `await` calls to fix Unhandled Promis Rejections
  when renaming the old config name to the new config name.
- Defaults CLI to the `help` command
- Uses `.bubblewrap` as the name for the config folder, in case we need to store other files in the future.

@chenlevy24 FYI