### PR TITLE
Improve prompts for the `init` command

### DIFF
--- a/packages/cli/src/lib/Prompt.ts
+++ b/packages/cli/src/lib/Prompt.ts
@@ -32,6 +32,12 @@ export type ValidateFunction<T> = (input: string) => Result<T, Error>;
  */
 export interface Prompt {
   /**
+   * Prints a message to the user.
+   * @param message the message to be printed.
+   */
+  printMessage(message: string): Promise<void>;
+
+  /**
    * Prompts for text input.
    * @param {string} message a short description of the input.
    * @param {string | null} defaultValue a default value or null.
@@ -106,6 +112,10 @@ function buildInquirerValidate<T>(validateFunction: ValidateFunction<T>):
  * A {@link Prompt} implementation powered by inquirer.js (https://www.npmjs.com/package/inquirer)
  */
 export class InquirerPrompt implements Prompt {
+  async printMessage(message: string): Promise<void> {
+    console.log(message);
+  }
+
   async promptInput<T>(
       message: string,
       defaultValue: string | null,

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -104,7 +104,7 @@ into a device:
 \t   - ${cyan('https://material.io/design/platform-guidance/android-bars.html')}.
 
 \t- ${bold('Status bar color:')} sets the status bar color used when the
-\t  application is in foreground.\n`,
+\t  application is in foreground. Example: ${cyan('#7CC0FF')}\n`,
   messageLauncherIconAndSplash: underline(`\nLauncher icons and splash screen ${green('(3/5)')}`),
   messageLauncherIconAndSplashDesc: `
 The Android app requires an image for the launcher icon. It also displays a
@@ -112,7 +112,7 @@ splash screen while the web content is loading, to avoid displaying a flash of
 a blank white page to users. 
 
 \t- ${bold('Splash screen color:')} sets the background colour used for the
-\t  splash screen.
+\t  splash screen. Example: ${cyan('#7CC0FF')}
 
 \t- ${bold('Icon URL:')} URL to an image that is at least 512x512px. Used to
 \t  generate the launcher icon for the application and the image for

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -14,7 +14,29 @@
  *  limitations under the License.
  */
 
+import {cyan, green, underline, bold, italic} from 'colors';
+
 type Messages = {
+  errorMaxLength: (maxLength: number, actualLength: number) => string;
+  errorMinLength: (minLength: number, actualLength: number) => string;
+  errorRequireHttps: string;
+  errorInvalidUrl: (url: string) => string;
+  errorInvalidColor: (color: string) => string;
+  errorInvalidDisplayMode: (displayMode: string) => string;
+  messageInitializingWebManifest: (manifestUrl: string) => string;
+  messageAndroidAppDetails: string;
+  messageAndroidAppDetailsDesc: string;
+  messageLauncherIconAndSplash: string;
+  messageLauncherIconAndSplashDesc: string;
+  messageOptionFeatures: string;
+  messageOptionalFeaturesDesc: string;
+  messageProjectGeneratedSuccess: string;
+  messageSigningKeyCreation: string;
+  messageSigningKeyInformation: string;
+  messageSigningKeyInformationDesc: string;
+  messageSigningKeyNotFound: (path: string) => string;
+  messageWebAppDetails: string;
+  messageWebAppDetailsDesc: string;
   promptHostMessage: string;
   promptName: string;
   promptLauncherName: string;
@@ -29,7 +51,7 @@ type Messages = {
   promptPackageId: string;
   promptKeyPath: string;
   promptKeyAlias: string;
-  promptCreateKey: (keypath: string) => string;
+  promptCreateKey: string;
   promptKeyFullName: string;
   promptKeyOrganizationalUnit: string;
   promptKeyOrganization: string;
@@ -37,43 +59,9 @@ type Messages = {
   promptKeystorePassword: string;
   promptKeyPassword: string;
   promptNewAppVersionName: string;
-  errorMaxLength: (maxLength: number, actualLength: number) => string;
-  errorMinLength: (minLength: number, actualLength: number) => string;
-  errorRequireHttps: string;
-  errorInvalidUrl: (url: string) => string;
-  errorInvalidColor: (color: string) => string;
-  errorInvalidDisplayMode: (displayMode: string) => string;
 }
 
 export const enUS: Messages = {
-  promptHostMessage: 'Domain being opened in the TWA:',
-  promptName: 'Name of the application:',
-  promptLauncherName: 'Name to be shown on the Android Launcher:',
-  promptDisplayMode: 'Display mode to be used:',
-  promptThemeColor: 'Color to be used for the status bar:',
-  promptBackgroundColor: 'Color to be used for the splash screen background:',
-  promptStartUrl: 'Relative path to open the TWA:',
-  promptIconUrl: 'URL to an image that is at least 512x512px:',
-  promptMaskableIconUrl: 'URL to an image that is at least 512x512px to be used when generating ' +
-  'maskable icons.\n\nMaskable icons should look good when their edges are removed by an icon ' +
-  'mask. They will be used to display adaptive launcher icons on the Android home screen.',
-  promptMonochromeIconUrl: 'URL to an image that is at least 48x48px to be used when generating ' +
-  'monochrome icons.\n\nMonochrome icons should look good when displayed with a single color,' +
-  'the PWA\' theme_color. They will be used for notification icons.',
-  promptShortcuts: 'Include app shortcuts?',
-  promptPackageId: 'Android Package Name (or Application ID):',
-  promptKeyPath: 'Location of the Signing Key:',
-  promptKeyAlias: 'Key name:',
-  promptCreateKey: (keypath: string): string => {
-    return `Signing Key could not be found at "${keypath}". Do you want to create one now?`;
-  },
-  promptKeyFullName: 'First and Last names (eg: John Doe):',
-  promptKeyOrganizationalUnit: 'Organizational Unit (eg: Engineering Dept):',
-  promptKeyOrganization: 'Organization (eg: Company Name):',
-  promptKeyCountry: 'Country (2 letter code):',
-  promptKeystorePassword: 'Password for the Key Store:',
-  promptKeyPassword: 'Password for the Key:',
-  promptNewAppVersionName: 'versionName for the new App version:',
   errorMaxLength: (maxLength, actualLength): string => {
     return `Maximum length is ${maxLength} but input is ${actualLength}.`;
   },
@@ -90,4 +78,120 @@ export const enUS: Messages = {
   errorInvalidDisplayMode: (displayMode: string): string => {
     return `Invalid display mode: ${displayMode}`;
   },
+  messageAndroidAppDetails: underline(`\nAndroid app details ${green('(2/5)')}`),
+  messageAndroidAppDetailsDesc: `
+Please, enter details regarding how the Android app will look when installed
+into a device:
+
+\t- ${bold('Application name:')} the name used in most places,
+\t  including the App information screen and on the Play Store.
+
+\t- ${bold('Short name:')} an alternate name for the app, limited to
+\t  12 characters, used on a device launch screen.
+
+\t- ${bold('Application ID:')} also known as ${italic('Package Name')}, this is
+\t  the unique identifier for the application on an Android device or
+\t  the Play Store. The name must contain at least two segments,
+\t  separated by dots, each segment must start with a letter and all
+\t  characters must be alphanumeric or an underscore (_).
+
+\t- ${bold('Display mode:')} how the app will be displayed on the
+\t  device screen when started. The default mode, used by most apps,
+\t  is ${cyan('standalone')}. ${cyan('fullscreen')} causes the device status bar and
+\t  navigation bars to be removed and is suitable for games or media
+\t  players. For more information on the status bars and navigation
+\t  bar on Android, go to:
+\t   - ${cyan('https://material.io/design/platform-guidance/android-bars.html')}.
+
+\t- ${bold('Status bar color:')} sets the status bar color used when the
+\t  application is in foreground.\n`,
+  messageLauncherIconAndSplash: underline(`\nLauncher icons and splash screen ${green('(3/5)')}`),
+  messageLauncherIconAndSplashDesc: `
+The Android app requires an image for the launcher icon. It also displays a
+splash screen while the web content is loading, to avoid displaying a flash of
+a blank white page to users. 
+
+\t- ${bold('Splash screen color:')} sets the background colour used for the
+\t  splash screen.
+
+\t- ${bold('Icon URL:')} URL to an image that is at least 512x512px. Used to
+\t  generate the launcher icon for the application and the image for
+\t  the splash screen.
+
+\t- ${bold('Maskable Icon URL (Optional):')} URL to an image that is at least
+\t  512x512px to be used when generating maskable icons. Maskable
+\t  icons should look good when their edges are removed by an icon
+\t  mask. They will be used to display adaptive launcher icons on the
+\t  Android home screen.\n`,
+  messageInitializingWebManifest: (manifestUrl: string): string => {
+    return `Initializing application from Web Manifest:\n\t-  ${cyan(manifestUrl)}`;
+  },
+  messageOptionFeatures: underline(`\nOptional Features ${green('(4/5)')}`),
+  messageOptionalFeaturesDesc: `
+\t- ${bold('Include app shortcuts:')} This question is only prompted if a
+\t  'shortcuts' section is available on the input Web Manifest. When
+\t  answered “yes”, Bubblewrap uses the information to generate
+\t  shortcuts on the Android app. Read more about app shortcuts at
+\t  ${cyan('https://web.dev/app-shortcuts/')}.
+
+\t- ${bold('Monochrome icon URL:')} URL to an image that is at least 48x48px to
+\t  be used when generating monochrome icons. Monochrome icons should
+\t  look good when displayed with a single color, the PWA's
+\t  ${italic('theme_color')}. They will be used for notification icons.\n`,
+  messageProjectGeneratedSuccess: '\nProject generated successfully. Build it by running ' +
+      cyan('bubblewrap build'),
+  messageSigningKeyCreation: underline('\nSigning key creation'),
+  messageSigningKeyInformation: underline(`\nSigning key information ${green('(5/5)')}`),
+  messageSigningKeyInformationDesc: `
+Please, enter information about the key store containing the that will be used
+to sign the application. If a key store does not exist on the provided path,
+Bubblewrap will prompt for the creation of a new keystore.
+
+\t- ${bold('Key store location:')} The location of the key store in the file
+\t  system.
+
+\t- ${bold('Key name:')} The alias used on the key.
+
+Read more about Android signing keys at:
+\t ${cyan('https://developer.android.com/studio/publish/app-signing')}\n`,
+  messageSigningKeyNotFound: (path: string): string => {
+    return `\nAn existing key store could could not be found at "${path}".\n`;
+  },
+  messageWebAppDetails: underline(`\nWeb app details ${green('(1/5)')}`),
+  messageWebAppDetailsDesc: `
+The application generated by Bubblewrap will open a Progressive Web App when
+started from the Android launcher. Please enter the following details about
+the PWA:
+  
+\t- ${bold('Domain:')} the domain / origin where the PWA is hosted. 
+\t  Example: ${cyan('example.com')}
+
+\t- ${bold('URL path:')} an URL path relative to the root of the origin,
+\t  opened when the application is started from the home screen.
+\t  Examples:
+
+\t\t- To open ${italic('https://example.com/')}: ${cyan('/')}
+\t\t- To open ${italic('https://example.com/path-to-pwa/')}: ${cyan('/path-to-pwa/')}\n`,
+  promptHostMessage: 'Domain:',
+  promptName: 'Application name:',
+  promptLauncherName: 'Short name:',
+  promptDisplayMode: 'Display mode:',
+  promptThemeColor: 'Status bar color:',
+  promptBackgroundColor: 'Splash screen color:',
+  promptStartUrl: 'URL path:',
+  promptIconUrl: 'Icon URL:',
+  promptMaskableIconUrl: 'Maskable icon URL:',
+  promptMonochromeIconUrl: 'Monochrome icon URL:',
+  promptShortcuts: 'Include app shortcuts?',
+  promptPackageId: 'Application ID:',
+  promptKeyPath: 'Key store location:',
+  promptKeyAlias: 'Key name:',
+  promptCreateKey: 'Do you want to create one now?',
+  promptKeyFullName: 'First and Last names (eg: John Doe):',
+  promptKeyOrganizationalUnit: 'Organizational Unit (eg: Engineering Dept):',
+  promptKeyOrganization: 'Organization (eg: Company Name):',
+  promptKeyCountry: 'Country (2 letter code):',
+  promptKeystorePassword: 'Password for the Key Store:',
+  promptKeyPassword: 'Password for the Key:',
+  promptNewAppVersionName: 'versionName for the new App version:',
 };


### PR DESCRIPTION
- Splits prompts into sections
- Adds more information to each section

See how it looks like below:
![init](https://user-images.githubusercontent.com/1733592/87053374-ca1ae880-c1f9-11ea-84fa-b6b5a46aad4a.gif)
