### PR TITLE
GradleWrapper can call bundleRelease

### DIFF
--- a/packages/core/src/lib/GradleWrapper.ts
+++ b/packages/core/src/lib/GradleWrapper.ts
@@ -51,7 +51,7 @@ export class GradleWrapper {
   async bundleRelease(): Promise<void> {
     const env = this.androidSdkTools.getEnv();
     await executeFile(
-      this.gradleCmd, ['bundleRelease', '--stacktrace'], env, undefined, this.projectLocation);
+        this.gradleCmd, ['bundleRelease', '--stacktrace'], env, undefined, this.projectLocation);
   }
 
   /**
@@ -60,6 +60,6 @@ export class GradleWrapper {
   async assembleRelease(): Promise<void> {
     const env = this.androidSdkTools.getEnv();
     await executeFile(
-      this.gradleCmd, ['assembleRelease', '--stacktrace'], env, undefined, this.projectLocation);
+        this.gradleCmd, ['assembleRelease', '--stacktrace'], env, undefined, this.projectLocation);
   }
 }

--- a/packages/core/src/lib/GradleWrapper.ts
+++ b/packages/core/src/lib/GradleWrapper.ts
@@ -14,11 +14,8 @@
  *  limitations under the License.
  */
 
-import * as util from 'util';
-import {exec} from 'child_process';
+import {executeFile} from './util';
 import {AndroidSdkTools} from './androidSdk/AndroidSdkTools';
-
-const execPromise = util.promisify(exec);
 
 /**
  * A Wrapper around the Gradle commands.
@@ -49,13 +46,20 @@ export class GradleWrapper {
   }
 
   /**
+   * Invokes `gradle bundleRelease` for the Android project.
+   */
+  async bundleRelease(): Promise<void> {
+    const env = this.androidSdkTools.getEnv();
+    await executeFile(
+      this.gradleCmd, ['bundleRelease', '--stacktrace'], env, undefined, this.projectLocation);
+  }
+
+  /**
    * Invokes `gradle assembleRelease` for the Android project.
    */
   async assembleRelease(): Promise<void> {
     const env = this.androidSdkTools.getEnv();
-    await execPromise(`${this.gradleCmd} assembleRelease --stacktrace`, {
-      env: env,
-      cwd: this.projectLocation,
-    });
+    await executeFile(
+      this.gradleCmd, ['assembleRelease', '--stacktrace'], env, undefined, this.projectLocation);
   }
 }

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -42,7 +42,7 @@ export async function execute(
 }
 
 export async function executeFile(
-    cmd: string, args: string[], env: NodeJS.ProcessEnv, log?: Log, cwd?: string
+    cmd: string, args: string[], env: NodeJS.ProcessEnv, log?: Log, cwd?: string,
 ): Promise<{stdout: string; stderr: string}> {
   if (log) {
     log.debug(`Executing command ${cmd} with args ${args}`);

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -42,12 +42,12 @@ export async function execute(
 }
 
 export async function executeFile(
-    cmd: string, args: string[], env: NodeJS.ProcessEnv, log?: Log,
+    cmd: string, args: string[], env: NodeJS.ProcessEnv, log?: Log, cwd?: string
 ): Promise<{stdout: string; stderr: string}> {
   if (log) {
     log.debug(`Executing command ${cmd} with args ${args}`);
   }
-  return await execFilePromise(cmd, args, {env: env});
+  return await execFilePromise(cmd, args, {env: env, cwd: cwd});
 }
 
 export async function downloadFile(url: string, path: string): Promise<void> {

--- a/packages/core/src/spec/lib/GradleWrapperSpec.ts
+++ b/packages/core/src/spec/lib/GradleWrapperSpec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {GradleWrapper} from '../../lib/GradleWrapper';
+import {Config} from '../../lib/Config';
+import {JdkHelper} from '../../lib/jdk/JdkHelper';
+import {AndroidSdkTools} from '../../lib/androidSdk/AndroidSdkTools';
+import * as util from '../../lib/util';
+import * as fs from 'fs';
+
+describe('GradleWrapper', () => {
+  let gradleWrapper: GradleWrapper;
+
+  beforeEach(() => {
+    spyOn(fs, 'existsSync').and.returnValue(true);
+    const config = new Config('/home/user/jdk8', '/home/user/sdktools');
+    const process = {
+      platform: 'linux',
+      env: {
+        'PATH': '',
+      },
+      cwd: () => '/path/to/twa-project/'
+    } as unknown as NodeJS.Process;
+    const jdkHelper = new JdkHelper(process, config);
+    const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
+    gradleWrapper = new GradleWrapper(process, androidSdkTools);
+  });
+
+  describe('#bundleRelease', () => {
+    it('Calls "gradle bundleRelease --stacktracke"', async () => {
+      spyOn(util, 'executeFile').and.stub();
+      await gradleWrapper.bundleRelease();
+      expect(util.executeFile).toHaveBeenCalled();
+    });
+  });
+
+  describe('#assembleRelease', async () => {
+    it('Calls "gradle assembleRelease --stacktrace"', async () => {
+      spyOn(util, 'executeFile').and.stub();
+      await gradleWrapper.assembleRelease();
+      expect(util.executeFile).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/spec/lib/GradleWrapperSpec.ts
+++ b/packages/core/src/spec/lib/GradleWrapperSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2020 Google Inc. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/packages/core/src/spec/lib/GradleWrapperSpec.ts
+++ b/packages/core/src/spec/lib/GradleWrapperSpec.ts
@@ -23,27 +23,31 @@ import * as fs from 'fs';
 
 describe('GradleWrapper', () => {
   let gradleWrapper: GradleWrapper;
+  let androidSdkTools: AndroidSdkTools;
+
+  const cwd = '/path/to/twa-project/';
+  const process = {
+    platform: 'linux',
+    env: {
+      'PATH': '',
+    },
+    cwd: () => cwd,
+  } as unknown as NodeJS.Process;
 
   beforeEach(() => {
     spyOn(fs, 'existsSync').and.returnValue(true);
     const config = new Config('/home/user/jdk8', '/home/user/sdktools');
-    const process = {
-      platform: 'linux',
-      env: {
-        'PATH': '',
-      },
-      cwd: () => '/path/to/twa-project/'
-    } as unknown as NodeJS.Process;
     const jdkHelper = new JdkHelper(process, config);
-    const androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
+    androidSdkTools = new AndroidSdkTools(process, config, jdkHelper);
     gradleWrapper = new GradleWrapper(process, androidSdkTools);
   });
 
   describe('#bundleRelease', () => {
-    it('Calls "gradle bundleRelease --stacktracke"', async () => {
+    it('Calls "gradle bundleRelease --stacktrace"', async () => {
       spyOn(util, 'executeFile').and.stub();
       await gradleWrapper.bundleRelease();
-      expect(util.executeFile).toHaveBeenCalled();
+      expect(util.executeFile).toHaveBeenCalledWith('./gradlew',
+          ['bundleRelease', '--stacktrace'], androidSdkTools.getEnv(), undefined, cwd);
     });
   });
 
@@ -51,7 +55,8 @@ describe('GradleWrapper', () => {
     it('Calls "gradle assembleRelease --stacktrace"', async () => {
       spyOn(util, 'executeFile').and.stub();
       await gradleWrapper.assembleRelease();
-      expect(util.executeFile).toHaveBeenCalled();
+      expect(util.executeFile).toHaveBeenCalledWith('./gradlew',
+          ['assembleRelease', '--stacktrace'], androidSdkTools.getEnv(), undefined, cwd);
     });
   });
 });


### PR DESCRIPTION
- Introduces a GradleWrapper method to call gradle bundleRelease
  to produce app bundles as output.

This moves forward work for #119 