### PR TITLE
OpenJDK contains lib, but not com

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,8 +48,8 @@ When running `bubblewrap` for the first time, it will ask where it can find the 
 line tools. So, take note of the location where both were decompressed.
 
 To ensure if you are taking note of the correct location, check if each directory contains the following files:
-- The **OpenJDK** path should contain `bin,com,include ..`
-- The **AndroidSDK** path should contain `tools` which should have `bin, cli`
+- The **OpenJDK** path should contain `bin`, `include` ,`lib`, ...
+- The **AndroidSDK** path should contain `tools` which should have `bin`, `cli`
 
 ### Updating the location of the JDK and / or the Android command line tools.
 If the location for the JDK or the Android command line tools have been setup with the wrong path or


### PR DESCRIPTION
This is the contents of the JDK I've just downloaded:

![image](https://user-images.githubusercontent.com/33569/87837659-1e047d80-c849-11ea-9ad5-5ced9a9958bd.png)
