### PR TITLE
Support of Android 11 and CrOS support update

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -166,5 +166,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.1'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.2'
 }

--- a/packages/core/template_project/build.gradle
+++ b/packages/core/template_project/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/packages/core/template_project/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/core/template_project/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip


### PR DESCRIPTION
- Bumps using android-browser-helper 1.3.2, for updated Chrome OS
  support.
- Updates the Gradle Plugin and Gradle versions in order to
  support the Android 11 `queries` section used on
  `android-browser-helper`.