### PR TITLE
Export es2018 code

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",

--- a/packages/core/src/spec/lib/GradleWrapperSpec.ts
+++ b/packages/core/src/spec/lib/GradleWrapperSpec.ts
@@ -51,7 +51,7 @@ describe('GradleWrapper', () => {
     });
   });
 
-  describe('#assembleRelease', async () => {
+  describe('#assembleRelease', () => {
     it('Calls "gradle assembleRelease --stacktrace"', async () => {
       spyOn(util, 'executeFile').and.stub();
       await gradleWrapper.assembleRelease();

--- a/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
+++ b/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
@@ -101,7 +101,7 @@ describe('KeyTool', () => {
     });
   });
 
-  describe('#list', async () => {
+  describe('#list', () => {
     const keyOptions = {
       path: '/',
       alias: 'keyalias',
@@ -141,4 +141,3 @@ describe('KeyTool', () => {
     });
   });
 });
-

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",
     "strict": true
   },
-  "include": ["src/**/*.ts"],  
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",
     "strict": true
   },
-  "include": ["src/**/*.ts", "src/spec/**/*.ts"],  
+  "include": ["src/**/*.ts", "src/spec/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This one small trick will save tons of code! [Node v10](https://node.green/) supports all es2018 syntax, and using it means async functions and classes aren't transpiled and are easier to debug.