### PR TITLE
Add site settings shortcut generation

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -135,7 +135,7 @@ export class TwaManifest {
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
     this.fallbackType = data.fallbackType || 'customtabs';
     this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ?
-    data.enableSiteSettingsShortcut : true;
+      data.enableSiteSettingsShortcut : true;
   }
 
   /**

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -70,6 +70,7 @@ export type FallbackType = 'customtabs' | 'webview';
  * navigationColor: '<%= themeColor %>', // The color used for the navigation bar.
  * backgroundColor: '<%= backgroundColor %>', // The color used for the splash screen background.
  * enableNotifications: false, // Set to true to enable notification delegation.
+ * enableSiteSettingsShortcut: false, // Set to true to enable a dynamic shortcut into site settings.
  * // Add shortcuts for your app here. Every shortcut must include the following fields:
  * // - name: String that will show up in the shortcut.
  * // - short_name: Shorter string used if |name| is too long.
@@ -105,6 +106,7 @@ export class TwaManifest {
   generatorApp: string;
   webManifestUrl?: URL;
   fallbackType: FallbackType;
+  enableSiteSettingsShortcut: boolean;
 
   private static log: Log = new Log('twa-manifest');
 
@@ -132,6 +134,7 @@ export class TwaManifest {
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
     this.fallbackType = data.fallbackType || 'customtabs';
+    this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ? data.enableSiteSettingsShortcut : true;
   }
 
   /**
@@ -304,6 +307,7 @@ export interface TwaManifestJson {
   generatorApp?: string;
   webManifestUrl?: string;
   fallbackType?: FallbackType;
+  enableSiteSettingsShortcut?: boolean;
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -134,7 +134,8 @@ export class TwaManifest {
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
     this.fallbackType = data.fallbackType || 'customtabs';
-    this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ? data.enableSiteSettingsShortcut : true;
+    this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ?
+    data.enableSiteSettingsShortcut : true;
   }
 
   /**

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -70,7 +70,7 @@ export type FallbackType = 'customtabs' | 'webview';
  * navigationColor: '<%= themeColor %>', // The color used for the navigation bar.
  * backgroundColor: '<%= backgroundColor %>', // The color used for the splash screen background.
  * enableNotifications: false, // Set to true to enable notification delegation.
- * enableSiteSettingsShortcut: false, // Set to true to enable a dynamic shortcut into site settings.
+ * enableSiteSettingsShortcut: true, // Set to false to disable the shortcut into site settings.
  * // Add shortcuts for your app here. Every shortcut must include the following fields:
  * // - name: String that will show up in the shortcut.
  * // - short_name: Shorter string used if |name| is too long.

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -204,6 +204,7 @@ describe('TwaManifest', () => {
         webManifestUrl: 'https://pwa-directory.com/manifest.json',
         generatorApp: 'test',
         fallbackType: 'webview',
+        enableSiteSettingsShortcut: false,
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
@@ -227,6 +228,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.webManifestUrl).toEqual(new URL(twaManifestJson.webManifestUrl!));
       expect(twaManifest.generatorApp).toEqual(twaManifestJson.generatorApp!);
       expect(twaManifest.fallbackType).toBe('webview');
+      expect(twaManifest.enableSiteSettingsShortcut).toEqual(false);
     });
 
     it('Sets correct default values for optional fields', () => {
@@ -249,12 +251,13 @@ describe('TwaManifest', () => {
         splashScreenFadeOutDuration: 300,
         enableNotifications: true,
         shortcuts: [{name: 'name', url: '/', chosenIconUrl: 'icon.png'}],
-        generatorApp: 'test',
+        generatorApp: 'test'
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.webManifestUrl).toBeUndefined();
       expect(twaManifest.fallbackType).toBe('customtabs');
       expect(twaManifest.display).toBe('standalone');
+      expect(twaManifest.enableSiteSettingsShortcut).toEqual(true);
     });
   });
 

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -251,7 +251,7 @@ describe('TwaManifest', () => {
         splashScreenFadeOutDuration: 300,
         enableNotifications: true,
         shortcuts: [{name: 'name', url: '/', chosenIconUrl: 'icon.png'}],
-        generatorApp: 'test'
+        generatorApp: 'test',
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.webManifestUrl).toBeUndefined();

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -39,7 +39,8 @@ def twaManifest = [
     generatorApp: '<%= generatorApp %>', // Application that generated the Android Project
     // The fallback strategy for when Trusted Web Activity is not avilable. Possible values are
     // 'customtabs' and 'webview'.
-    fallbackType: '<%= fallbackType %>'
+    fallbackType: '<%= fallbackType %>',
+    enableSiteSettingsShortcut: '<%= enableSiteSettingsShortcut %>',
 ]
 
 android {
@@ -115,6 +116,8 @@ android {
         resValue "string", "generatorApp", twaManifest.generatorApp
 
         resValue "string", "fallbackType", twaManifest.fallbackType
+
+        resValue "bool", "enableSiteSettingsShortcut", twaManifest.enableSiteSettingsShortcut
     }
     buildTypes {
         release {

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -169,5 +169,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.2'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0'
 }

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -50,7 +50,6 @@
             android:name="twa_generator"
             android:value="@string/generatorApp" />
 
-
         <% if (enableSiteSettingsShortcut) { %>
             <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
             <meta-data
@@ -59,7 +58,6 @@
             </activity>
         <% } %>
         
-
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
             android:label="@string/launcherName">
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/appName"
+        <% if (enableSiteSettingsShortcut) { %>
+        android:manageSpaceActivity="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity"
+        <% } %>
         android:supportsRtl="true"
         android:theme="@style/Theme.LauncherActivity">
 
@@ -46,6 +49,16 @@
         <meta-data
             android:name="twa_generator"
             android:value="@string/generatorApp" />
+
+
+        <% if (enableSiteSettingsShortcut) { %>
+            <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
+            <meta-data
+                android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"
+                android:value="@string/launchUrl" />
+            </activity>
+        <% } %>
+        
 
         <activity android:name="com.google.androidbrowserhelper.trusted.LauncherActivity"
             android:label="@string/launcherName">


### PR DESCRIPTION
- Add a variable enableSiteSettingsShortcut into TwaManifest.ts that defaults to true
- Add ManageDataLauncherActivity into the template manifest
- Add enableSiteSettingsShortcut into tests

Behaviour tested by running npm run test and also by building an .apk and launching it in an android emulator.