### PR TITLE
Add divider color functionality

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -72,7 +72,7 @@ export type FallbackType = 'customtabs' | 'webview';
  * navigationColorDark: '<%= navigationColorDark %>', // The color used for the dark navbar.
  * navigationDividerColor: '<%= navigationDividerColor %>', // The color used for the
  * navbar divider.
- * navigationDividerColorDark: '<%= navigationDividerColorDark %>', // The color used for the dark 
+ * navigationDividerColorDark: '<%= navigationDividerColorDark %>', // The color used for the dark
  * navbar divider.
  * backgroundColor: '<%= backgroundColor %>', // The color used for the splash screen background.
  * enableNotifications: false, // Set to true to enable notification delegation.

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -129,12 +129,12 @@ export class TwaManifest {
     this.display = asDisplayMode(data.display!) || DEFAULT_DISPLAY_MODE;
     this.themeColor = new Color(data.themeColor);
     this.navigationColor = new Color(data.navigationColor);
-    this.navigationColorDark = data.navigationColorDark == undefined ?
-      new Color(DEFAULT_NAVIGATION_COLOR) : new Color(data.navigationColorDark);
-    this.navigationDividerColor = data.navigationDividerColor == undefined ?
-      new Color(DEFAULT_NAVIGATION_DIVIDER_COLOR) : new Color(data.navigationDividerColor);
-    this.navigationDividerColorDark = data.navigationDividerColorDark == undefined ?
-    new Color(DEFAULT_NAVIGATION_COLOR) : new Color(data.navigationDividerColorDark);
+    this.navigationColorDark = new Color(data.navigationColorDark == undefined ?
+      DEFAULT_NAVIGATION_COLOR : data.navigationColorDark);
+    this.navigationDividerColor = new Color(data.navigationDividerColor == undefined ?
+      DEFAULT_NAVIGATION_DIVIDER_COLOR : data.navigationDividerColor);
+    this.navigationDividerColorDark = new Color(data.navigationDividerColorDark == undefined ?
+      DEFAULT_NAVIGATION_COLOR : data.navigationDividerColorDark);
     this.backgroundColor = new Color(data.backgroundColor);
     this.enableNotifications = data.enableNotifications;
     this.startUrl = data.startUrl;

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -129,12 +129,11 @@ export class TwaManifest {
     this.display = asDisplayMode(data.display!) || DEFAULT_DISPLAY_MODE;
     this.themeColor = new Color(data.themeColor);
     this.navigationColor = new Color(data.navigationColor);
-    this.navigationColorDark = new Color(data.navigationColorDark == undefined ?
-      DEFAULT_NAVIGATION_COLOR : data.navigationColorDark);
-    this.navigationDividerColor = new Color(data.navigationDividerColor == undefined ?
-      DEFAULT_NAVIGATION_DIVIDER_COLOR : data.navigationDividerColor);
-    this.navigationDividerColorDark = new Color(data.navigationDividerColorDark == undefined ?
-      DEFAULT_NAVIGATION_COLOR : data.navigationDividerColorDark);
+    this.navigationColorDark = new Color(data.navigationColorDark ?? DEFAULT_NAVIGATION_COLOR);
+    this.navigationDividerColor = new Color(data.navigationDividerColor ??
+      DEFAULT_NAVIGATION_DIVIDER_COLOR);
+    this.navigationDividerColorDark = new Color(data.navigationDividerColorDark ??
+      DEFAULT_NAVIGATION_COLOR);
     this.backgroundColor = new Color(data.backgroundColor);
     this.enableNotifications = data.enableNotifications;
     this.startUrl = data.startUrl;

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -48,6 +48,7 @@ const DEFAULT_APP_NAME = 'My TWA';
 const DEFAULT_DISPLAY_MODE = 'standalone';
 const DEFAULT_THEME_COLOR = '#FFFFFF';
 const DEFAULT_NAVIGATION_COLOR = '#000000';
+const DEFAULT_NAVIGATION_DIVIDER_COLOR = '#00000000';
 const DEFAULT_BACKGROUND_COLOR = '#FFFFFF';
 const DEFAULT_APP_VERSION_CODE = 1;
 const DEFAULT_APP_VERSION_NAME = DEFAULT_APP_VERSION_CODE.toString();
@@ -68,6 +69,11 @@ export type FallbackType = 'customtabs' | 'webview';
  * display: '<%= display %>', // The display mode for the TWA.
  * themeColor: '<%= themeColor %>', // The color used for the status bar.
  * navigationColor: '<%= themeColor %>', // The color used for the navigation bar.
+ * navigationColorDark: '<%= navigationColorDark %>', // The color used for the dark navbar.
+ * navigationDividerColor: '<%= navigationDividerColor %>', // The color used for the
+ * navbar divider.
+ * navigationDividerColorDark: '<%= navigationDividerColorDark %>', // The color used for the dark 
+ * navbar divider.
  * backgroundColor: '<%= backgroundColor %>', // The color used for the splash screen background.
  * enableNotifications: false, // Set to true to enable notification delegation.
  * enableSiteSettingsShortcut: true, // Set to false to disable the shortcut into site settings.
@@ -92,6 +98,9 @@ export class TwaManifest {
   display: DisplayMode;
   themeColor: Color;
   navigationColor: Color;
+  navigationColorDark: Color;
+  navigationDividerColor: Color;
+  navigationDividerColorDark: Color;
   backgroundColor: Color;
   enableNotifications: boolean;
   startUrl: string;
@@ -120,6 +129,12 @@ export class TwaManifest {
     this.display = asDisplayMode(data.display!) || DEFAULT_DISPLAY_MODE;
     this.themeColor = new Color(data.themeColor);
     this.navigationColor = new Color(data.navigationColor);
+    this.navigationColorDark = data.navigationColorDark == undefined ?
+      new Color(DEFAULT_NAVIGATION_COLOR) : new Color(data.navigationColorDark);
+    this.navigationDividerColor = data.navigationDividerColor == undefined ?
+      new Color(DEFAULT_NAVIGATION_DIVIDER_COLOR) : new Color(data.navigationDividerColor);
+    this.navigationDividerColorDark = data.navigationDividerColorDark == undefined ?
+    new Color(DEFAULT_NAVIGATION_COLOR) : new Color(data.navigationDividerColorDark);
     this.backgroundColor = new Color(data.backgroundColor);
     this.enableNotifications = data.enableNotifications;
     this.startUrl = data.startUrl;
@@ -148,6 +163,9 @@ export class TwaManifest {
     const json: TwaManifestJson = Object.assign({}, this, {
       themeColor: this.themeColor.hex(),
       navigationColor: this.navigationColor.hex(),
+      navigationColorDark: this.navigationColorDark.hex(),
+      navigationDividerColor: this.navigationDividerColor.hex(),
+      navigationDividerColorDark: this.navigationDividerColorDark.hex(),
       backgroundColor: this.backgroundColor.hex(),
       appVersion: this.appVersionName,
       webManifestUrl: this.webManifestUrl ? this.webManifestUrl.toString() : undefined,
@@ -241,6 +259,9 @@ export class TwaManifest {
       display: asDisplayMode(webManifest['display']!) || DEFAULT_DISPLAY_MODE,
       themeColor: webManifest['theme_color'] || DEFAULT_THEME_COLOR,
       navigationColor: DEFAULT_NAVIGATION_COLOR,
+      navigationColorDark: DEFAULT_NAVIGATION_COLOR,
+      navigationDividerColor: DEFAULT_NAVIGATION_DIVIDER_COLOR,
+      navigationDividerColorDark: DEFAULT_NAVIGATION_DIVIDER_COLOR,
       backgroundColor: webManifest['background_color'] || DEFAULT_BACKGROUND_COLOR,
       startUrl: fullStartUrl.pathname + fullStartUrl.search,
       iconUrl: resolveIconUrl(icon),
@@ -294,6 +315,9 @@ export interface TwaManifestJson {
   display?: string; // Older Manifests may not have this field.
   themeColor: string;
   navigationColor: string;
+  navigationColorDark?: string;
+  navigationDividerColor?: string;
+  navigationDividerColorDark?: string;
   backgroundColor: string;
   enableNotifications: boolean;
   startUrl: string;

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -60,6 +60,9 @@ describe('TwaManifest', () => {
       expect(twaManifest.monochromeIconUrl).toBeUndefined();
       expect(twaManifest.themeColor.hex()).toBe('#00FF00');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
+      expect(twaManifest.navigationColorDark.hex()).toBe('#000000');
+      expect(twaManifest.navigationDividerColor.hex()).toBe('#000000');
+      expect(twaManifest.navigationDividerColorDark.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#7CC0FF');
       expect(twaManifest.appVersionName).toBe('1');
       expect(twaManifest.appVersionCode).toBe(1);
@@ -95,6 +98,9 @@ describe('TwaManifest', () => {
       expect(twaManifest.display).toBe('standalone');
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
+      expect(twaManifest.navigationColorDark.hex()).toBe('#000000');
+      expect(twaManifest.navigationDividerColor.hex()).toBe('#000000');
+      expect(twaManifest.navigationDividerColorDark.hex()).toBe('#000000');
       expect(twaManifest.backgroundColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.appVersionName).toBe('1');
       expect(twaManifest.appVersionCode).toBe(1);
@@ -191,6 +197,9 @@ describe('TwaManifest', () => {
         display: 'fullscreen',
         themeColor: '#00ff00',
         navigationColor: '#000000',
+        navigationColorDark: '#ffffff',
+        navigationDividerColor: '#ff0000',
+        navigationDividerColorDark: '#dddddd',
         backgroundColor: '#0000ff',
         appVersion: '1.0.0',
         appVersionCode: 10,
@@ -216,6 +225,9 @@ describe('TwaManifest', () => {
       expect(twaManifest.display).toEqual('fullscreen');
       expect(twaManifest.themeColor).toEqual(new Color('#00ff00'));
       expect(twaManifest.navigationColor).toEqual(new Color('#000000'));
+      expect(twaManifest.navigationColorDark).toEqual(new Color('#ffffff'));
+      expect(twaManifest.navigationDividerColor).toEqual(new Color('#ff0000'));
+      expect(twaManifest.navigationDividerColorDark).toEqual(new Color('#dddddd'));
       expect(twaManifest.backgroundColor).toEqual(new Color('#0000ff'));
       expect(twaManifest.appVersionName).toEqual(twaManifestJson.appVersion);
       expect(twaManifest.appVersionCode).toEqual(twaManifestJson.appVersionCode!);
@@ -258,6 +270,10 @@ describe('TwaManifest', () => {
       expect(twaManifest.fallbackType).toBe('customtabs');
       expect(twaManifest.display).toBe('standalone');
       expect(twaManifest.enableSiteSettingsShortcut).toEqual(true);
+      expect(twaManifest.navigationColor).toEqual(new Color('#000000'));
+      expect(twaManifest.navigationDividerColor).toEqual(new Color('#00000000'));
+      expect(twaManifest.navigationDividerColorDark).toEqual(new Color('#000000'));
+
     });
   });
 

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -273,7 +273,6 @@ describe('TwaManifest', () => {
       expect(twaManifest.navigationColor).toEqual(new Color('#000000'));
       expect(twaManifest.navigationDividerColor).toEqual(new Color('#00000000'));
       expect(twaManifest.navigationDividerColorDark).toEqual(new Color('#000000'));
-
     });
   });
 

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -26,6 +26,9 @@ def twaManifest = [
     launcherName: '<%= launcherName %>', // The name shown on the Android Launcher.
     themeColor: '<%= themeColor.hex() %>', // The color used for the status bar.
     navigationColor: '<%= navigationColor.hex() %>', // The color used for the navigation bar.
+    navigationColorDark: '<%= navigationColorDark.hex() %>', // The color used for the dark navbar.
+    navigationDividerColor: '<%= navigationDividerColor.hex() %>', // The navbar divider color.
+    navigationDividerColorDark: '<%= navigationDividerColorDark.hex() %>', // The dark navbar divider color.
     backgroundColor: '<%= backgroundColor.hex() %>', // The color used for the splash screen background.
     enableNotifications: <%= enableNotifications %>, // Set to true to enable notification delegation.
     // Every shortcut must include the following fields:
@@ -87,10 +90,25 @@ android {
         // compile. If not set, the status bar color defaults to #FFFFFF - white.
         resValue "color", "colorPrimary", twaManifest.themeColor
 
-        // This attribute sets the navigation bar color for the TWA. It can be either set here or in
-        // `res/values/colors.xml`. Setting in both places is an error and the app will not
+        // This attribute sets the navigation bar color for the TWA. It can be either set here or
+        // in `res/values/colors.xml`. Setting in both places is an error and the app will not
         // compile. If not set, the navigation bar color defaults to #FFFFFF - white.
         resValue "color", "navigationColor", twaManifest.navigationColor
+
+        // This attribute sets the dark navigation bar color for the TWA. It can be either set here
+        // or in `res/values/colors.xml`. Setting in both places is an error and the app will not
+        // compile. If not set, the navigation bar color defaults to #000000 - black.
+        resValue "color", "navigationColorDark", twaManifest.navigationColorDark
+
+        // This attribute sets the navbar divider color for the TWA. It can be either 
+        // set here or in `res/values/colors.xml`. Setting in both places is an error and the app 
+        // will not compile. If not set, the divider color defaults to #00000000 - transparent.
+        resValue "color", "navigationDividerColor", twaManifest.navigationDividerColor
+
+        // This attribute sets the dark navbar divider color for the TWA. It can be either 
+        // set here or in `res/values/colors.xml`. Setting in both places is an error and the 
+        //app will not compile. If not set, the divider color defaults to #000000 - black.
+        resValue "color", "navigationDividerColorDark", twaManifest.navigationDividerColorDark
 
         // Sets the color for the background used for the splash screen when launching the
         // Trusted Web Activity.

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -71,6 +71,18 @@
                 android:name="android.support.customtabs.trusted.NAVIGATION_BAR_COLOR"
                 android:resource="@color/navigationColor" />
 
+            <meta-data
+                android:name="android.support.customtabs.trusted.NAVIGATION_BAR_COLOR_DARK"
+                android:resource="@color/navigationColorDark" />
+
+            <meta-data
+                android:name="androix.browser.trusted.NAVIGATION_BAR_DIVIDER_COLOR"
+                android:resource="@color/navigationDividerColor" />
+
+            <meta-data
+                android:name="androix.browser.trusted.NAVIGATION_BAR_DIVIDER_COLOR_DARK"
+                android:resource="@color/navigationDividerColorDark" />
+
             <meta-data android:name="android.support.customtabs.trusted.SPLASH_IMAGE_DRAWABLE"
                 android:resource="@drawable/splash"/>
 


### PR DESCRIPTION
Add support for changing navbar divider color in TWAs generated via bubblewrap

Users required the ability to change the color of the navigation bar
divider custom tabs, which in some cases looked inconsistent. After adding
this feature to chromium and androidX, this PR adds it into bubblewrap
via a navigationColor variable that can be set in the web-manifest.json

Test: Tested the integration of bubblewrap and android-browser-helper 
by building an example app and changing the navbar color. 
Also modified tests to account for new navbar color variables.

Closes #66 