### PR TITLE
Enable a ChromeOS Only Build

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -93,6 +93,8 @@ type Features = {
  *  ],
  * // The duration of fade out animation in milliseconds to be played when removing splash screen.
  * splashScreenFadeOutDuration: 300
+ * isChromeOSOnly: false, // Setting to true will enable a feature that prevents non-ChromeOS devices
+ *  from installing the app.
  *
  */
 export class TwaManifest {
@@ -122,6 +124,7 @@ export class TwaManifest {
   fallbackType: FallbackType;
   features: Features;
   enableSiteSettingsShortcut: boolean;
+  isChromeOSOnly: boolean;
 
   private static log = new ConsoleLog('twa-manifest');
 
@@ -157,6 +160,7 @@ export class TwaManifest {
     this.features = data.features || {};
     this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ?
       data.enableSiteSettingsShortcut : true;
+    this.isChromeOSOnly = data.isChromeOSOnly != undefined ? data.isChromeOSOnly : false;
   }
 
   /**
@@ -342,6 +346,7 @@ export interface TwaManifestJson {
     appsFlyer?: AppsFlyerConfig;
   };
   enableSiteSettingsShortcut?: boolean;
+  isChromeOSOnly?: boolean;
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -214,6 +214,7 @@ describe('TwaManifest', () => {
         generatorApp: 'test',
         fallbackType: 'webview',
         enableSiteSettingsShortcut: false,
+        isChromeOSOnly: false,
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
@@ -241,6 +242,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.generatorApp).toEqual(twaManifestJson.generatorApp!);
       expect(twaManifest.fallbackType).toBe('webview');
       expect(twaManifest.enableSiteSettingsShortcut).toEqual(false);
+      expect(twaManifest.isChromeOSOnly).toEqual(false);
     });
 
     it('Sets correct default values for optional fields', () => {

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -26,6 +26,10 @@
         <uses-permission android:name="<%= permission %>"/>
     <% } %>
 
+    <% if (isChromeOSOnly) { %>
+    <uses-feature android:name="org.chromium.arc" android:required="true" />
+    <% } %>
+
     <application
         android:name="Application"
         android:allowBackup="true"


### PR DESCRIPTION
This changes the TWAManifest to specify whether the build should be
designated as a ChromeOS Only package for distribution through Play.
Otherwise, the build will be available to all devices.

Closes #320 