### PR TITLE
Added the `rmdir` method

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -17,6 +17,7 @@
 import * as extractZip from 'extract-zip';
 import fetch from 'node-fetch';
 import * as fs from 'fs';
+import {join} from 'path';
 import {promisify} from 'util';
 import {exec, execFile, spawn} from 'child_process';
 import {x as extractTar} from 'tar';
@@ -224,3 +225,23 @@ export function validatePackageId(input: string): string | null{
   }
   return null;
 }
+
+/**
+ * Removes a file or directory. If the path is a directory, recursively deletes files and
+ * directories inside it.
+ */
+export async function rmdirs(path: string): Promise<void> {
+  const stat = await fs.promises.stat(path);
+
+  // This is a regular file. Just delete it.
+  if (stat.isFile()) {
+    await fs.promises.unlink(path);
+    return;
+  }
+
+  // This is a directory. We delete files and sub directories inside it, then delete the
+  // directory itself.
+  const entries = fs.readdirSync(path);
+  await Promise.all(entries.map((entry) => rmdirs(join(path, entry))));
+  await fs.promises.rmdir(path);
+};

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -230,7 +230,7 @@ export function validatePackageId(input: string): string | null{
  * Removes a file or directory. If the path is a directory, recursively deletes files and
  * directories inside it.
  */
-export async function rmdirs(path: string): Promise<void> {
+export async function rmdir(path: string): Promise<void> {
   const stat = await fs.promises.stat(path);
 
   // This is a regular file. Just delete it.
@@ -242,6 +242,6 @@ export async function rmdirs(path: string): Promise<void> {
   // This is a directory. We delete files and sub directories inside it, then delete the
   // directory itself.
   const entries = fs.readdirSync(path);
-  await Promise.all(entries.map((entry) => rmdirs(join(path, entry))));
+  await Promise.all(entries.map((entry) => rmdir(join(path, entry))));
   await fs.promises.rmdir(path);
 };

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -231,6 +231,9 @@ export function validatePackageId(input: string): string | null{
  * directories inside it.
  */
 export async function rmdir(path: string): Promise<void> {
+  if (!fs.existsSync(path)) {
+    return;
+  }
   const stat = await fs.promises.stat(path);
 
   // This is a regular file. Just delete it.

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -230,7 +230,7 @@ describe('util', () => {
   describe('rmdirs', () => {
     it('Deletes a single file', async () => {
       mockFs({'/app.txt': 'Test Content'});
-      await util.rmdirs('/app.txt');
+      await util.rmdir('/app.txt');
       expect(existsSync('/app.txt')).toBeFalse();
       mockFs.restore();
     });
@@ -245,7 +245,7 @@ describe('util', () => {
         },
         '/other-file.txt': 'This should not be deleted',
       });
-      await util.rmdirs('/test');
+      await util.rmdir('/test');
       expect(existsSync('/test')).toBeFalse();
       expect(existsSync('/other-file.txt')).toBeTrue();
       mockFs.restore();
@@ -253,7 +253,7 @@ describe('util', () => {
 
     it('Skips empty directory', () => {
       mockFs({});
-      expectAsync(util.rmdirs('/app.txt')).toBeResolved();
+      expectAsync(util.rmdir('/app.txt')).toBeResolved();
       mockFs.restore();
     });
   });

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -15,6 +15,8 @@
  */
 
 import * as util from '../../lib/util';
+import * as mockFs from 'mock-fs';
+import {existsSync} from 'fs';
 
 describe('util', () => {
   describe('#findSuitableIcon', () => {
@@ -222,6 +224,36 @@ describe('util', () => {
       expect(util.validatePackageId('1com.char.twa')).not.toBeNull();
       expect(util.validatePackageId('com.char.1twa')).not.toBeNull();
       expect(util.validatePackageId('_com.char.1twa')).not.toBeNull();
+    });
+  });
+
+  describe('rmdirs', () => {
+    it('Deletes a single file', async () => {
+      mockFs({'/app.txt': 'Test Content'});
+      await util.rmdirs('/app.txt');
+      expect(existsSync('/app.txt')).toBeFalse();
+      mockFs.restore();
+    });
+
+    it('Deletes a directory', async () => {
+      mockFs({
+        '/test': {
+          'app.txt': 'Test Content',
+          'subdirectory': {
+            'file2.txt': 'Test Content 2',
+          },
+        },
+        '/other-file.txt': 'This should not be deleted',
+      });
+      await util.rmdirs('/test');
+      expect(existsSync('/test')).toBeFalse();
+      expect(existsSync('/other-file.txt')).toBeTrue();
+    });
+
+    it('Skips empty directory', () => {
+      mockFs({});
+      expectAsync(util.rmdirs('/app.txt')).toBeResolved();
+      mockFs.restore();
     });
   });
 });

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -248,6 +248,7 @@ describe('util', () => {
       await util.rmdirs('/test');
       expect(existsSync('/test')).toBeFalse();
       expect(existsSync('/other-file.txt')).toBeTrue();
+      mockFs.restore();
     });
 
     it('Skips empty directory', () => {


### PR DESCRIPTION
This function is used to delete a file or directory hierarchy and
will be used to clean an existing project before regenerating it.

More context in #326 