### PR TITLE
Fixed reading shortcuts from twa manifest

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -153,7 +153,10 @@ export class TwaManifest {
     this.signingKey = data.signingKey;
     this.appVersionName = data.appVersion;
     this.appVersionCode = data.appVersionCode || DEFAULT_APP_VERSION_CODE;
-    this.shortcuts = data.shortcuts;
+    this.shortcuts = data.shortcuts.map((si) => {
+      return new ShortcutInfo(si.name, si.shortName, si.url, si.chosenIconUrl,
+          si.chosenMaskableIconUrl, si.chosenMonochromeIconUrl);
+    });
     this.generatorApp = data.generatorApp || DEFAULT_GENERATOR_APP_NAME;
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
     this.fallbackType = data.fallbackType || 'customtabs';

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -153,7 +153,7 @@ export class TwaManifest {
     this.signingKey = data.signingKey;
     this.appVersionName = data.appVersion;
     this.appVersionCode = data.appVersionCode || DEFAULT_APP_VERSION_CODE;
-    this.shortcuts = data.shortcuts.map((si) => {
+    this.shortcuts = (data.shortcuts || []).map((si) => {
       return new ShortcutInfo(si.name, si.shortName, si.url, si.chosenIconUrl,
           si.chosenMaskableIconUrl, si.chosenMonochromeIconUrl);
     });
@@ -341,7 +341,7 @@ export interface TwaManifestJson {
   signingKey: SigningKeyInfo;
   appVersionCode?: number; // Older Manifests may not have this field.
   appVersion: string; // appVersionName - Old Manifests use `appVersion`. Keeping compatibility.
-  shortcuts: ShortcutInfo[];
+  shortcuts?: ShortcutInfo[];
   generatorApp?: string;
   webManifestUrl?: string;
   fallbackType?: FallbackType;

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -17,7 +17,7 @@
 import {TwaManifest, TwaManifestJson, asDisplayMode} from '../../lib/TwaManifest';
 import {WebManifestJson} from '../../lib/types/WebManifest';
 import Color = require('color');
-import { ShortcutInfo } from '../../lib/ShortcutInfo';
+import {ShortcutInfo} from '../../lib/ShortcutInfo';
 
 describe('TwaManifest', () => {
   describe('#fromWebManifestJson', () => {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -17,6 +17,7 @@
 import {TwaManifest, TwaManifestJson, asDisplayMode} from '../../lib/TwaManifest';
 import {WebManifestJson} from '../../lib/types/WebManifest';
 import Color = require('color');
+import { ShortcutInfo } from '../../lib/ShortcutInfo';
 
 describe('TwaManifest', () => {
   describe('#fromWebManifestJson', () => {
@@ -237,7 +238,8 @@ describe('TwaManifest', () => {
       expect(twaManifest.splashScreenFadeOutDuration)
           .toEqual(twaManifestJson.splashScreenFadeOutDuration);
       expect(twaManifest.enableNotifications).toEqual(twaManifestJson.enableNotifications);
-      expect(twaManifest.shortcuts).toEqual(twaManifestJson.shortcuts);
+      expect(twaManifest.shortcuts)
+          .toEqual([new ShortcutInfo('name', 'shortName', '/', 'icon.png')]);
       expect(twaManifest.webManifestUrl).toEqual(new URL(twaManifestJson.webManifestUrl!));
       expect(twaManifest.generatorApp).toEqual(twaManifestJson.generatorApp!);
       expect(twaManifest.fallbackType).toBe('webview');


### PR DESCRIPTION
`update` was crashing with method not found: `assetName`. Loading
the JSON from the file doesn't automatically assign methods to
the shortcut. So, we create proper shortcuts when creating the
TwaManifest from the JSON.