### PR TITLE
Improved error messages and fixes tests running on MacOS

### DIFF
--- a/packages/cli/src/spec/DoctorSpec.ts
+++ b/packages/cli/src/spec/DoctorSpec.ts
@@ -24,6 +24,24 @@ import {MockPrompt} from './mock/MockPrompt';
 import {enUS as messages} from '../lib/strings';
 
 describe('doctor', () => {
+  let originalProcess: NodeJS.Process;
+
+  beforeEach(() => {
+    // Set process to a linux platform so we can run the test against expected paths on MacOS and
+    // Windows.
+    process = {
+      platform: 'linux',
+      env: {
+        'PATH': '',
+      },
+    } as unknown as NodeJS.Process;
+  });
+
+  afterEach(() => {
+    // Resets to the original process to avoid breaking other tests.
+    process = originalProcess;
+  });
+
   describe('#jdkDoctor', () => {
     it('checks that the expected error message is sent in case that the path given isn\'t' +
         ' valid', async () => {

--- a/packages/core/src/spec/lib/jdk/JdkHelperSpec.ts
+++ b/packages/core/src/spec/lib/jdk/JdkHelperSpec.ts
@@ -20,17 +20,32 @@ import {JdkHelper} from '../../../lib/jdk/JdkHelper';
 import {Config} from '../../../lib/Config';
 import * as mock from 'mock-fs';
 
+const WIN32_PROCESS = {
+  platform: 'win32',
+  env: {
+    'Path': '',
+  },
+} as unknown as NodeJS.Process;
+
+const LINUX_PROCESS = {
+  platform: 'linux',
+  env: {
+    'PATH': '',
+  },
+} as unknown as NodeJS.Process;
+
+const MACOS_PROCESS = {
+  platform: 'darwin',
+  env: {
+    'PATH': '',
+  },
+} as unknown as NodeJS.Process;
+
 describe('JdkHelper', () => {
   describe('getEnv()', () => {
     it('Creates the correct environment for Linux', () => {
       const config = new Config('/home/user/jdk8', '/home/user/sdktools');
-      const process = {
-        platform: 'linux',
-        env: {
-          'PATH': '',
-        },
-      } as unknown as NodeJS.Process;
-      const jdkHelper = new JdkHelper(process, config);
+      const jdkHelper = new JdkHelper(LINUX_PROCESS, config);
       const env = jdkHelper.getEnv();
       expect(env['PATH']).toBe('/home/user/jdk8/bin/:');
       expect(env['JAVA_HOME']).toBe('/home/user/jdk8/');
@@ -38,13 +53,7 @@ describe('JdkHelper', () => {
 
     it('Creates the correct environment for MacOSX', () => {
       const config = new Config('/home/user/jdk8', '/home/user/sdktools');
-      const process = {
-        platform: 'darwin',
-        env: {
-          'PATH': '',
-        },
-      } as unknown as NodeJS.Process;
-      const jdkHelper = new JdkHelper(process, config);
+      const jdkHelper = new JdkHelper(MACOS_PROCESS, config);
       const env = jdkHelper.getEnv();
       expect(env['JAVA_HOME']).toBe('/home/user/jdk8/Contents/Home/');
       expect(env['PATH']).toBe('/home/user/jdk8/Contents/Home/bin/:');
@@ -52,13 +61,7 @@ describe('JdkHelper', () => {
 
     it('Creates the correct environment for Windows', () => {
       const config = new Config('C:\\Users\\user\\jdk8', 'C:\\Users\\user\\sdktools');
-      const process = {
-        platform: 'win32',
-        env: {
-          'Path': '',
-        },
-      } as unknown as NodeJS.Process;
-      const jdkHelper = new JdkHelper(process, config);
+      const jdkHelper = new JdkHelper(WIN32_PROCESS, config);
       const env = jdkHelper.getEnv();
       expect(env['Path']).toBe('C:\\Users\\user\\jdk8\\bin\\;');
       expect(env['JAVA_HOME']).toBe('C:\\Users\\user\\jdk8\\');
@@ -66,22 +69,49 @@ describe('JdkHelper', () => {
   });
 
   describe('validatePath', () => {
-    it('Creates a Windows environment and checks that a valid path will pass', async () => {
+    it('Creates a Linux environment and checks that a valid path will pass', async () => {
       mock({
         'jdk': {
           'release': 'JAVA_VERSION="1.8',
         }});
-      expect((await JdkHelper.validatePath('jdk')).isOk()).toBeTrue();
+      expect((await JdkHelper.validatePath('jdk', LINUX_PROCESS)).isOk()).toBeTrue();
       mock.restore();
     });
 
-    it('Creates a Windows environment and checks that an invalid path will not pass', async () => {
+    it('Creates a Linux environment and checks that an invalid path will not pass', async () => {
       mock({
         'jdk': {
           'release': {},
         }});
-      expect((await JdkHelper.validatePath('jdk')).isError()).toBeTrue();
-      expect((await JdkHelper.validatePath('release')).isError()).toBeTrue();
+      expect((await JdkHelper.validatePath('jdk', LINUX_PROCESS)).isError()).toBeTrue();
+      expect((await JdkHelper.validatePath('release', LINUX_PROCESS)).isError()).toBeTrue();
+      mock.restore();
+    });
+
+    it('Creates a MacOS environment and checks that a valid path will pass', async () => {
+      mock({
+        'jdk': {
+          'Contents': {
+            'Home': {
+              'release': 'JAVA_VERSION="1.8"',
+            },
+          },
+        }});
+      expect((await JdkHelper.validatePath('jdk', MACOS_PROCESS)).isOk()).toBeTrue();
+      mock.restore();
+    });
+
+    it('Creates a MacOS environment and checks that an invalid path will not pass', async () => {
+      mock({
+        'jdk': {
+          'Contents': {
+            'Home': {
+              'release': 'JAVA_VERSION="1.9"',
+            },
+          },
+        }});
+      expect((await JdkHelper.validatePath('jdk', MACOS_PROCESS)).isError()).toBeTrue();
+      expect((await JdkHelper.validatePath('release', MACOS_PROCESS)).isError()).toBeTrue();
       mock.restore();
     });
   });
@@ -95,13 +125,7 @@ describe('JdkHelper', () => {
           'jre': {},
           'release': 'JAVA_VERSION="1.8.0_265',
         }});
-      const process = {
-        platform: 'win32',
-        env: {
-          'Path': '',
-        },
-      } as unknown as NodeJS.Process;
-      expect(JdkHelper.getJavaHome('jdk8u265-b01', process)).toEqual('jdk8u265-b01\\');
+      expect(JdkHelper.getJavaHome('jdk8u265-b01', WIN32_PROCESS)).toEqual('jdk8u265-b01\\');
       mock.restore();
     });
 
@@ -118,13 +142,8 @@ describe('JdkHelper', () => {
           'MacOS': {},
           'info.plist': {},
         }});
-      const process = {
-        platform: 'darwin',
-        env: {
-          'Path': '',
-        },
-      } as unknown as NodeJS.Process;
-      expect(JdkHelper.getJavaHome('jdk8u265-b01', process)).toEqual('jdk8u265-b01/Contents/Home/');
+      expect(JdkHelper.getJavaHome('jdk8u265-b01', MACOS_PROCESS))
+          .toEqual('jdk8u265-b01/Contents/Home/');
       mock.restore();
     });
 
@@ -136,13 +155,7 @@ describe('JdkHelper', () => {
           'jre': {},
           'release': 'JAVA_VERSION="1.8.0_265',
         }});
-      const process = {
-        platform: 'linux',
-        env: {
-          'Path': '',
-        },
-      } as unknown as NodeJS.Process;
-      expect(JdkHelper.getJavaHome('jdk8u265-b01', process)).toEqual('jdk8u265-b01/');
+      expect(JdkHelper.getJavaHome('jdk8u265-b01', LINUX_PROCESS)).toEqual('jdk8u265-b01/');
       mock.restore();
     });
   });


### PR DESCRIPTION
- Fixed type.
- Added the JDK path to the error message.
- Fixed tests failing on MacOS due to platform differences.