### PR TITLE
fix app shortcuts to not fail with "app isn't installed" error

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -174,7 +174,7 @@ task generateShorcutsFile {
                     'intent'(
                             'android:action': 'android.intent.action.MAIN',
                             'android:targetPackage': twaManifest.applicationId,
-                            'android:targetClass': 'com.google.androidbrowserhelper.trusted.LauncherActivity',
+                            'android:targetClass': twaManifest.applicationId + '.LauncherActivity',
                             'android:data': s.url)
                     'categories'('android:name': 'android.intent.category.LAUNCHER')
                 }


### PR DESCRIPTION
Tried quite a few things to get the shortcuts to work with bubblewrap as created from imgflip.com/manifest.json, but nothing worked even though they work fine when installed as a standard progressive web app. This targetClass seemed out of place and changing it finally made the shortcuts work when testing locally with `bubblewrap install`.