### PR TITLE
Added a progress function to util.downloadFile

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -51,12 +51,34 @@ export async function executeFile(
   return await execFilePromise(cmd, args, {env: env, cwd: cwd});
 }
 
-export async function downloadFile(url: string, path: string): Promise<void> {
+/**
+ * Downloads a file from `url` and saves it to `path`. If a `progressCallback` function is passed, it
+ * will be invoked for every chunk received. If the value of `total` parameter is -1, it means we
+ * were unable to determine to total file size before starting the download.
+ */
+export async function downloadFile(url: string, path: string,
+    progressCallback?: (current: number, total: number) => void): Promise<void> {
   const result = await fetch(url);
+
+  // Try to determine the file size via the `Content-Length` header. This may not be available
+  // for all cases.
+  const contentLength = result.headers.get('content-length');
+  const fileSize = contentLength ? parseInt(contentLength) : -1;
+
   const fileStream = fs.createWriteStream(path);
+  let received = 0;
 
   await new Promise((resolve, reject) => {
     result.body.pipe(fileStream);
+
+    // Even though we're piping the chunks, we intercept them to check for the download progress.
+    if (progressCallback) {
+      result.body.on('data', (chunk) => {
+        received = received + chunk.length;
+        progressCallback(received, fileSize);
+      });
+    }
+
     result.body.on('error', (err) => {
       reject(err);
     });


### PR DESCRIPTION
- When set, the function is invoked for every chunk received.
- If we're unable to determine the total file size, the function
  is invoked with totalSize as -1.