### PR TITLE
Add the Chrome OS only flag to init.

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -119,11 +119,12 @@ parse the Web manifest and generate default valuers for the Android project, whe
 will prompt the user to confirm or input values where one could not be generated.
 
 ```
-bubblewrap init --manifest="<web-manifest-url>" [--directory="<path-to-output-location>"]
+bubblewrap init --manifest="<web-manifest-url>" [--directory="<path-to-output-location>"] [--chromeosonly]
 ```
 
 Options:
   - `--directory`: path where to generate the project. Defaults to the current directory.
+  - `--chromeosonly`: this flag specifies that the build will be used for Chrome OS only and prevents non-Chrome OS devices from installing the app.
 
 ## `build`
 

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -188,6 +188,9 @@ export async function init(
     args: ParsedArgs, config: Config, prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
   prompt.printMessage(messages.messageInitializingWebManifest(args.manifest));
   let twaManifest = await TwaManifest.fromWebManifest(args.manifest);
+  if (args.chromeosonly) {
+    twaManifest.isChromeOSOnly = true;
+  }
   twaManifest = await confirmTwaConfig(twaManifest, prompt);
   const twaGenerator = new TwaGenerator();
   const targetDirectory = args.directory || process.cwd();


### PR DESCRIPTION
It was brought to my attention that most developers pursuing bubblewrap
would already know that they want to specify a ChromeOS only build. This
allows those developers to specify ChromeOS only from the beginning,
preventing them from needing to go back and modify the TWA-Manifest file
later on.