### PR TITLE
Allows enabling/disable a feature in the twa-manifest.

### DIFF
--- a/packages/core/src/lib/features/AppsFlyerFeature.ts
+++ b/packages/core/src/lib/features/AppsFlyerFeature.ts
@@ -17,6 +17,7 @@
 import {EmptyFeature} from './EmptyFeature';
 
 export type AppsFlyerConfig = {
+  enabled: boolean;
   appsFlyerId: string;
 }
 

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -48,11 +48,11 @@ export class FeatureManager {
    * Builds a new intance from a TwaManifest.
    */
   constructor(twaManifest: TwaManifest) {
-    if (twaManifest.features.appsFlyer !== undefined) {
+    if (twaManifest.features.appsFlyer && twaManifest.features.appsFlyer.enabled) {
       this.addFeature(new AppsFlyerFeature(twaManifest.features.appsFlyer));
     }
 
-    if (twaManifest.features.firstRunFlag !== undefined) {
+    if (twaManifest.features.firstRunFlag && twaManifest.features.firstRunFlag.enabled) {
       this.addFeature(new FirstRunFlagFeature(twaManifest.features.firstRunFlag));
     }
 

--- a/packages/core/src/lib/features/FirstRunFlagFeature.ts
+++ b/packages/core/src/lib/features/FirstRunFlagFeature.ts
@@ -17,6 +17,7 @@
 import {EmptyFeature} from './EmptyFeature';
 
 export interface FirstRunFlagConfig {
+  enabled: boolean;
   queryParameterName: string;
 }
 

--- a/packages/core/src/spec/lib/features/AppsFlyerFeatureSpec.ts
+++ b/packages/core/src/spec/lib/features/AppsFlyerFeatureSpec.ts
@@ -21,6 +21,7 @@ describe('AppsFlyerFeature', () => {
     // variables is the only field dynamically generated.
     it('Generates correct variables for application', () => {
       const config = {
+        enabled: true,
         appsFlyerId: '12345',
       } as AppsFlyerConfig;
       const appsFlyerFeature = new AppsFlyerFeature(config);

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -89,10 +89,12 @@ describe('FeatureManager', () => {
 
     it('Features are applied to FeatureManager', () => {
       const appsFlyerConfig = {
+        enabled: true,
         appsFlyerId: '12345',
       } as AppsFlyerConfig;
 
       const firstRunFlagConfig = {
+        enabled: true,
         queryParameterName: 'query_parameter',
       } as FirstRunFlagConfig;
 

--- a/packages/core/src/spec/lib/features/FirstRunFlagFeatureSpec.ts
+++ b/packages/core/src/spec/lib/features/FirstRunFlagFeatureSpec.ts
@@ -22,6 +22,7 @@ describe('FirstRunFlagFeature', () => {
       const paramName = 'my_param_name';
       // variables is the only field dynamically generated.
       const config = {
+        enabled: true,
         queryParameterName: paramName,
       } as FirstRunFlagConfig;
       const appsFlyerFeature = new FirstRunFlagFeature(config);


### PR DESCRIPTION
- Features were automatically enabled when added to the twa-manifest.
- This allows finer control and disabling features without removing
  them from the Manifest.