### PR TITLE
Added alphaDependencies

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -66,6 +66,10 @@ type Features = {
   firstRunFlag?: FirstRunFlagConfig;
 }
 
+type alphaDependencies = {
+  enabled: boolean;
+}
+
 /**
  * A Manifest used to generate the TWA Project
  *
@@ -125,6 +129,7 @@ export class TwaManifest {
   webManifestUrl?: URL;
   fallbackType: FallbackType;
   features: Features;
+  alphaDependencies: alphaDependencies;
   enableSiteSettingsShortcut: boolean;
   isChromeOSOnly: boolean;
 
@@ -163,6 +168,7 @@ export class TwaManifest {
     this.webManifestUrl = data.webManifestUrl ? new URL(data.webManifestUrl) : undefined;
     this.fallbackType = data.fallbackType || 'customtabs';
     this.features = data.features || {};
+    this.alphaDependencies = data.alphaDependencies || {enabled: false};
     this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ?
       data.enableSiteSettingsShortcut : true;
     this.isChromeOSOnly = data.isChromeOSOnly != undefined ? data.isChromeOSOnly : false;

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -456,6 +456,9 @@ export interface TwaManifestJson {
     appsFlyer?: AppsFlyerConfig;
     firstRunFlag?: FirstRunFlagConfig;
   };
+  alphaDependencies?: {
+    enabled: boolean;
+  };
   enableSiteSettingsShortcut?: boolean;
   isChromeOSOnly?: boolean;
 }

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -60,6 +60,14 @@ export class FeatureManager {
     if (twaManifest.fallbackType === 'webview') {
       this.androidManifest.permissions.add('android.permission.INTERNET');
     }
+
+    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
+      this.buildGradle.dependencies.add(
+          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
+    } else {
+      this.buildGradle.dependencies.add(
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0');
+    }
   }
 
   private addFeature(feature: Feature): void {

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -61,7 +61,7 @@ export class FeatureManager {
       this.androidManifest.permissions.add('android.permission.INTERNET');
     }
 
-    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled === true) {
+    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
       this.buildGradle.dependencies.add(
           'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
     } else {

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -61,7 +61,7 @@ export class FeatureManager {
       this.androidManifest.permissions.add('android.permission.INTERNET');
     }
 
-    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
+    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled === true) {
       this.buildGradle.dependencies.add(
           'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
     } else {

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -72,11 +72,22 @@ describe('FeatureManager', () => {
       expect(features.applicationClass.imports).toEqual(emptySet);
       expect(features.applicationClass.onCreate).toEqual([]);
       expect(features.applicationClass.variables).toEqual([]);
-      expect(features.buildGradle.dependencies).
-          toEqual((new Set().add('com.google.androidbrowserhelper:androidbrowserhelper:2.0.0')));
+      expect(features.buildGradle.dependencies).toEqual((new Set().
+          add('com.google.androidbrowserhelper:androidbrowserhelper:2.0.0')));
       expect(features.buildGradle.repositories).toEqual(emptySet);
       expect(features.launcherActivity.imports).toEqual(emptySet);
       expect(features.launcherActivity.launchUrl).toEqual([]);
+    });
+
+    it('Creates from empty features with alpha features unabled', () => {
+      const manifest = {
+        features: {},
+        fallbackType: 'customtabs',
+        alphaDependencies: {enabled: true},
+      } as TwaManifest;
+      const features = new FeatureManager(manifest);
+      expect(features.buildGradle.dependencies).toEqual((new Set().
+          add('com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01')));
     });
 
     it('Adds INTERNET permission when WebView fallback is enabled', () => {

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -72,8 +72,8 @@ describe('FeatureManager', () => {
       expect(features.applicationClass.imports).toEqual(emptySet);
       expect(features.applicationClass.onCreate).toEqual([]);
       expect(features.applicationClass.variables).toEqual([]);
-      expect(features.buildGradle.dependencies).toEqual((new Set().
-          add('com.google.androidbrowserhelper:androidbrowserhelper:2.0.0')));
+      expect(features.buildGradle.dependencies).toContain(
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0');
       expect(features.buildGradle.repositories).toEqual(emptySet);
       expect(features.launcherActivity.imports).toEqual(emptySet);
       expect(features.launcherActivity.launchUrl).toEqual([]);
@@ -86,8 +86,8 @@ describe('FeatureManager', () => {
         alphaDependencies: {enabled: true},
       } as TwaManifest;
       const features = new FeatureManager(manifest);
-      expect(features.buildGradle.dependencies).toEqual((new Set().
-          add('com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01')));
+      expect(features.buildGradle.dependencies).toContain(
+          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
     });
 
     it('Adds INTERNET permission when WebView fallback is enabled', () => {

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -72,7 +72,8 @@ describe('FeatureManager', () => {
       expect(features.applicationClass.imports).toEqual(emptySet);
       expect(features.applicationClass.onCreate).toEqual([]);
       expect(features.applicationClass.variables).toEqual([]);
-      expect(features.buildGradle.dependencies).toEqual(emptySet);
+      expect(features.buildGradle.dependencies).
+          toEqual((new Set().add('com.google.androidbrowserhelper:androidbrowserhelper:2.0.0')));
       expect(features.buildGradle.repositories).toEqual(emptySet);
       expect(features.launcherActivity.imports).toEqual(emptySet);
       expect(features.launcherActivity.launchUrl).toEqual([]);

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -79,7 +79,7 @@ describe('FeatureManager', () => {
       expect(features.launcherActivity.launchUrl).toEqual([]);
     });
 
-    it('Creates from empty features with alpha features unabled', () => {
+    it('Creates from empty features with alpha features enabled', () => {
       const manifest = {
         features: {},
         fallbackType: 'customtabs',

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -196,11 +196,9 @@ dependencies {
     <% for(const dep of buildGradle.dependencies) { %>
         implementation '<%= dep %>'
     <% } %>
-     if (twaManifest.alphaFeatures && twaManifest.alphaFeatures.enabled) {
-      this.buildGradle.dependencies.add(
-          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
+    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
+        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01' 
     } else {
-      this.buildGradle.dependencies.add(
-          'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0');
-    }
+        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0' 
+    }    
 }

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -196,9 +196,11 @@ dependencies {
     <% for(const dep of buildGradle.dependencies) { %>
         implementation '<%= dep %>'
     <% } %>
-    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
-        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01' 
+     if (twaManifest.alphaFeatures && twaManifest.alphaFeatures.enabled) {
+      this.buildGradle.dependencies.add(
+          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
     } else {
-        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0' 
-    }    
+      this.buildGradle.dependencies.add(
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0');
+    }
 }

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -196,9 +196,5 @@ dependencies {
     <% for(const dep of buildGradle.dependencies) { %>
         implementation '<%= dep %>'
     <% } %>
-    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
-        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01' 
-    } else {
-        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0' 
-    }    
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0'    
 }

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -196,5 +196,4 @@ dependencies {
     <% for(const dep of buildGradle.dependencies) { %>
         implementation '<%= dep %>'
     <% } %>
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0'    
 }

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -196,5 +196,9 @@ dependencies {
     <% for(const dep of buildGradle.dependencies) { %>
         implementation '<%= dep %>'
     <% } %>
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0'    
+    if (twaManifest.alphaDependencies && twaManifest.alphaDependencies.enabled) {
+        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01' 
+    } else {
+        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.0' 
+    }    
 }


### PR DESCRIPTION
Added alphaDependencies to `twaManifest.json` and added a check of that field in `app/build.gradle`. If it turned on, we will use version 2.0 of androidBrowserHelper, else we will use the current version.