### PR TITLE
Web share target support - string resources save

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -72,6 +72,11 @@ android {
             resValue "string", "webManifestUrl", '<%= webManifestUrl %>'
         <% } %>
 
+        <% if (twaManifest.webShare) { %>
+            // The data for the app to support web share target.
+            resValue "string", "webShare", twaManifest.webShare
+        <% } %>
+
         // The hostname is used when building the intent-filter, so the TWA is able to
         // handle Intents to open https://svgomg.firebaseapp.com.
         resValue "string", "hostName", twaManifest.hostName


### PR DESCRIPTION
Now we save the share target data as a string resource.