### PR TITLE
Revert "Web share target support - string resources save"

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -72,11 +72,6 @@ android {
             resValue "string", "webManifestUrl", '<%= webManifestUrl %>'
         <% } %>
 
-        <% if (twaManifest.webShare) { %>
-            // The data for the app to support web share target.
-            resValue "string", "webShare", twaManifest.webShare
-        <% } %>
-
         // The hostname is used when building the intent-filter, so the TWA is able to
         // handle Intents to open https://svgomg.firebaseapp.com.
         resValue "string", "hostName", twaManifest.hostName


### PR DESCRIPTION
Reverts GoogleChromeLabs/bubblewrap#377

This PR is broken for a couple of reasons:
 - `twaManifest.webShare`doesn't exist.
 - Usually, we'd use `webShare` directly (see other variables), but that's not defined in `TwaManifest`either.
```
        <% if (twaManifest.webShare) { %>
            // The data for the app to support web share target.
            resValue "string", "webShare", twaManifest.webShare
        <% } %>
```