### PR TITLE
Commented out share_target implementation

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -297,7 +297,7 @@ export class TwaManifest {
       features: {
         locationDelegation: {enabled: DEFAULT_ENABLE_LOCATION},
       },
-      shareTarget: undefined,//webManifest['share_target'],
+      shareTarget: undefined, //webManifest['share_target'],
     });
     return twaManifest;
   }

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -21,7 +21,7 @@ import fetch from 'node-fetch';
 import {findSuitableIcon, generatePackageId, validateNotEmpty} from './util';
 import Color = require('color');
 import {ConsoleLog} from './Log';
-import {WebManifestIcon, WebManifestJson} from './types/WebManifest';
+import {ShareTarget, WebManifestIcon, WebManifestJson} from './types/WebManifest';
 import {ShortcutInfo} from './ShortcutInfo';
 import {AppsFlyerConfig} from './features/AppsFlyerFeature';
 import {LocationDelegationConfig} from './features/LocationDelegationFeature';
@@ -135,7 +135,7 @@ export class TwaManifest {
   alphaDependencies: alphaDependencies;
   enableSiteSettingsShortcut: boolean;
   isChromeOSOnly: boolean;
-  shareTargetJson?: string;
+  shareTarget?: ShareTarget;
 
   private static log = new ConsoleLog('twa-manifest');
 
@@ -176,7 +176,7 @@ export class TwaManifest {
     this.enableSiteSettingsShortcut = data.enableSiteSettingsShortcut != undefined ?
       data.enableSiteSettingsShortcut : true;
     this.isChromeOSOnly = data.isChromeOSOnly != undefined ? data.isChromeOSOnly : false;
-    this.shareTargetJson = data.shareTargetJson;
+    this.shareTarget = data.shareTarget;
   }
 
   /**
@@ -297,7 +297,7 @@ export class TwaManifest {
       features: {
         locationDelegation: {enabled: DEFAULT_ENABLE_LOCATION},
       },
-      shareTargetJson: JSON.stringify(webManifest['share_target']),
+      shareTarget: undefined,//webManifest['share_target'],
     });
     return twaManifest;
   }
@@ -477,7 +477,7 @@ export interface TwaManifestJson {
   };
   enableSiteSettingsShortcut?: boolean;
   isChromeOSOnly?: boolean;
-  shareTargetJson?: string;
+  shareTarget?: ShareTarget;
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -297,7 +297,7 @@ export class TwaManifest {
       features: {
         locationDelegation: {enabled: DEFAULT_ENABLE_LOCATION},
       },
-      shareTarget: undefined, //webManifest['share_target'],
+      shareTarget: undefined, // webManifest['share_target'],
     });
     return twaManifest;
   }

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -297,7 +297,11 @@ export class TwaManifest {
       features: {
         locationDelegation: {enabled: DEFAULT_ENABLE_LOCATION},
       },
-      shareTarget: undefined, // webManifest['share_target'],
+      // We're leaving `shareTarget` as undefined for now, as the shareTarget is not complete
+      // and we want to avoid creating manifests with invalid values for now. The broader Web Share
+      // Target implementation is being tracked at
+      // https://github.com/GoogleChromeLabs/bubblewrap/issues/21.
+      shareTarget: undefined,
     });
     return twaManifest;
   }


### PR DESCRIPTION
The share_target implementation is breaking the build. This PR
fixes what is breaking it.

We also set the shareTarget variable to `undefined`, effectively
disabling the feature. The reason being that no validation is
being done in the value read from the Web Manifest, which can
potentially generate an invalid TWA Manifest.

Related to #21