### PR TITLE
Added progress bar when downloading SDKs

### DIFF
--- a/packages/cli/src/lib/AndroidSdkToolsInstaller.ts
+++ b/packages/cli/src/lib/AndroidSdkToolsInstaller.ts
@@ -15,28 +15,36 @@
  */
 
 import * as path from 'path';
-import * as util from '../util';
+import {util} from '@bubblewrap/core';
+import {Prompt} from './Prompt';
+import {Presets, Bar} from 'cli-progress';
+import {green} from 'colors';
+import {enUS as messages} from './strings';
 
 const SDK_VERSION = '6609375';
 const DOWNLOAD_SDK_ROOT = 'https://dl.google.com/android/repository/';
 const WINDOWS_URL = `commandlinetools-win-${SDK_VERSION}_latest.zip`;
 const MAC_URL = `commandlinetools-mac-${SDK_VERSION}_latest.zip`;
 const LINUX_URL = `commandlinetools-linux-${SDK_VERSION}_latest.zip`;
+const ANDROID_SDK_SIZE = 86532338;
 
 /**
  * Install Android Command Line Tools by downloading the zip and
  * decompressing it.
  */
 export class AndroidSdkToolsInstaller {
+  constructor(private process: NodeJS.Process, private prompt: Prompt) {
+  }
+
   /**
    * Downloads the platform-appropriate version of Android
    * Command Line Tools.
    *
    * @param installPath {string} path to install SDK at.
    */
-  static async install(installPath: string): Promise<void> {
+  async install(installPath: string): Promise<void> {
     let downloadFileName;
-    switch (process.platform) {
+    switch (this.process.platform) {
       case 'darwin': {
         downloadFileName = MAC_URL;
         break;
@@ -49,13 +57,25 @@ export class AndroidSdkToolsInstaller {
         downloadFileName = WINDOWS_URL;
         break;
       }
-      default: throw new Error(`Unsupported Platform: ${process.platform}`);
+      default: throw new Error(`Unsupported Platform: ${this.process.platform}`);
     }
 
     const dstPath = path.resolve(installPath);
     const downloadUrl = DOWNLOAD_SDK_ROOT + downloadFileName;
     const localPath = path.join(dstPath, downloadFileName);
-    await util.downloadFile(downloadUrl, localPath);
+    this.prompt.printMessage(messages.messageDownloadAndroidSdk);
+
+    const progressBar = new Bar({
+      format: ` >> [${green('{bar}')}] {percentage}% | {value}k of {total}k`,
+    }, Presets.shades_classic);
+
+    progressBar.start(Math.round(ANDROID_SDK_SIZE / 1024), 0);
+    await util.downloadFile(downloadUrl, localPath, (current) => {
+      progressBar.update(Math.round(current / 1024));
+    });
+    progressBar.stop();
+
+    this.prompt.printMessage(messages.messageDecompressAndroidSdk);
     await util.unzipFile(localPath, dstPath, true);
   }
 }

--- a/packages/cli/src/lib/AndroidSdkToolsInstaller.ts
+++ b/packages/cli/src/lib/AndroidSdkToolsInstaller.ts
@@ -17,8 +17,6 @@
 import * as path from 'path';
 import {util} from '@bubblewrap/core';
 import {Prompt} from './Prompt';
-import {Presets, Bar} from 'cli-progress';
-import {green} from 'colors';
 import {enUS as messages} from './strings';
 
 const SDK_VERSION = '6609375';
@@ -26,7 +24,6 @@ const DOWNLOAD_SDK_ROOT = 'https://dl.google.com/android/repository/';
 const WINDOWS_URL = `commandlinetools-win-${SDK_VERSION}_latest.zip`;
 const MAC_URL = `commandlinetools-mac-${SDK_VERSION}_latest.zip`;
 const LINUX_URL = `commandlinetools-linux-${SDK_VERSION}_latest.zip`;
-const ANDROID_SDK_SIZE = 86532338;
 
 /**
  * Install Android Command Line Tools by downloading the zip and
@@ -63,17 +60,9 @@ export class AndroidSdkToolsInstaller {
     const dstPath = path.resolve(installPath);
     const downloadUrl = DOWNLOAD_SDK_ROOT + downloadFileName;
     const localPath = path.join(dstPath, downloadFileName);
+
     this.prompt.printMessage(messages.messageDownloadAndroidSdk);
-
-    const progressBar = new Bar({
-      format: ` >> [${green('{bar}')}] {percentage}% | {value}k of {total}k`,
-    }, Presets.shades_classic);
-
-    progressBar.start(Math.round(ANDROID_SDK_SIZE / 1024), 0);
-    await util.downloadFile(downloadUrl, localPath, (current) => {
-      progressBar.update(Math.round(current / 1024));
-    });
-    progressBar.stop();
+    await this.prompt.downloadFile(downloadUrl, localPath);
 
     this.prompt.printMessage(messages.messageDecompressAndroidSdk);
     await util.unzipFile(localPath, dstPath, true);

--- a/packages/cli/src/lib/Prompt.ts
+++ b/packages/cli/src/lib/Prompt.ts
@@ -195,7 +195,7 @@ export class InquirerPrompt implements Prompt {
     progressBar.start(Math.round(totalSize / KILOBYTE_SIZE), 0);
     await util.downloadFile(url, filename, (current, total) => {
       if (total > 0 && total !== totalSize) {
-        progressBar.setTotal(total / KILOBYTE_SIZE);
+        progressBar.setTotal(Math.round(total / KILOBYTE_SIZE));
         totalSize = total;
       }
       progressBar.update(Math.round(current / KILOBYTE_SIZE));

--- a/packages/cli/src/lib/Prompt.ts
+++ b/packages/cli/src/lib/Prompt.ts
@@ -14,8 +14,12 @@
  *  limitations under the License.
  */
 
-import {Result} from '@bubblewrap/core';
+import {Result, util} from '@bubblewrap/core';
+import {Presets, Bar} from 'cli-progress';
+import {green} from 'colors';
 import * as inquirer from 'inquirer';
+
+const KILOBYTE_SIZE = 1024;
 
 /**
  * A function that takes a `string`, validates and tries to convert to the type `T`, and returns a
@@ -88,6 +92,15 @@ export interface Prompt {
    * value will the `true` if the user answers `Yes` and `false` for `No`.
    */
   promptConfirm(message: string, defaultValue: boolean): Promise<boolean>;
+
+  /**
+   * Downloads a file from `url` and saves it as `filename` and shows the download progress.
+   * Optionaly, the total file size can be passed as `totalSize`.
+   * @param url the url to download the file from.
+   * @param filename the filename to save the file.
+   * @param totalSize an optional total file size.
+   */
+  downloadFile(url: string, filename: string, totalSize?: number): Promise<void>;
 }
 
 // Builds an Inquirer validate function from a `ValidateFunction<T>`. From the inquirer docs:
@@ -172,5 +185,21 @@ export class InquirerPrompt implements Prompt {
       mask: '*',
     });
     return (await validateFunction(result.question)).unwrap();
+  }
+
+  async downloadFile(url: string, filename: string, totalSize = 0): Promise<void> {
+    const progressBar = new Bar({
+      format: ` >> [${green('{bar}')}] {percentage}% | {value}k of {total}k`,
+    }, Presets.shades_classic);
+
+    progressBar.start(Math.round(totalSize / KILOBYTE_SIZE), 0);
+    await util.downloadFile(url, filename, (current, total) => {
+      if (total > 0 && total !== totalSize) {
+        progressBar.setTotal(total / KILOBYTE_SIZE);
+        totalSize = total;
+      }
+      progressBar.update(Math.round(current / KILOBYTE_SIZE));
+    });
+    progressBar.stop();
   }
 }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -17,8 +17,9 @@
 
 import {join} from 'path';
 import {homedir} from 'os';
-import {Config, Log, ConsoleLog, JdkInstaller, JdkHelper, AndroidSdkTools,
-  AndroidSdkToolsInstaller} from '@bubblewrap/core';
+import {Config, Log, ConsoleLog, JdkHelper, AndroidSdkTools} from '@bubblewrap/core';
+import {JdkInstaller} from './JdkInstaller';
+import {AndroidSdkToolsInstaller} from './AndroidSdkToolsInstaller';
 import {existsSync} from 'fs';
 import {enUS as messages} from './strings';
 import {promises as fsPromises} from 'fs';
@@ -43,7 +44,7 @@ async function createConfig(prompt: Prompt = new InquirerPrompt()): Promise<Conf
   } else {
     await fsPromises.mkdir(DEFAULT_JDK_FOLDER, {recursive: true});
     prompt.printMessage(messages.messageDownloadJdk + DEFAULT_JDK_FOLDER);
-    const jdkInstaller = new JdkInstaller(process);
+    const jdkInstaller = new JdkInstaller(process, prompt);
     jdkPath = await jdkInstaller.install(DEFAULT_JDK_FOLDER);
   }
 
@@ -58,7 +59,8 @@ async function createConfig(prompt: Prompt = new InquirerPrompt()): Promise<Conf
     if (sdkTermsAgreement) {
       await fsPromises.mkdir(DEFAULT_SDK_FOLDER, {recursive: true});
       prompt.printMessage(messages.messageDownloadSdk + DEFAULT_SDK_FOLDER);
-      await AndroidSdkToolsInstaller.install(DEFAULT_SDK_FOLDER);
+      const androidSdkToolsInstaller = new AndroidSdkToolsInstaller(process, prompt);
+      await androidSdkToolsInstaller.install(DEFAULT_SDK_FOLDER);
       sdkPath = DEFAULT_SDK_FOLDER;
     } else {
       throw new Error(messages.errorSdkTerms);

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -55,6 +55,12 @@ type Messages = {
   messageWebAppDetailsDesc: string;
   messageDownloadJdk: string;
   messageDownloadSdk: string;
+  messageDownloadJdkSrc: string;
+  messageDecompressJdkSrc: string;
+  messageDownloadJdkBin: string;
+  messageDecompressJdkBin: string;
+  messageDownloadAndroidSdk: string;
+  messageDecompressAndroidSdk: string;
   promptInstallJdk: string;
   promptJdkPath: string;
   promptInstallSdk: string;
@@ -243,6 +249,12 @@ the PWA:
 \t\t- To open ${italic('https://example.com/path-to-pwa/')}: ${cyan('/path-to-pwa/')}\n`,
   messageDownloadJdk: 'Downloading JDK 8 to ',
   messageDownloadSdk: 'Downloading Android SDK to ',
+  messageDownloadJdkSrc: 'Downloading the JDK 8 Sources...',
+  messageDecompressJdkSrc: 'Decompressing the JDK 8 Sources...',
+  messageDownloadJdkBin: 'Downloading the JDK 8 Binaries...',
+  messageDecompressJdkBin: 'Decompressing the JDK 8 Binaries...',
+  messageDownloadAndroidSdk: 'Downloading the Android SDK...',
+  messageDecompressAndroidSdk: 'Decompressing the Android SDK...',
   promptInstallJdk: `Do you want Bubblewrap to install JDK?
   (Enter "No" to use your JDK installation)`,
   promptJdkPath: 'Path to your existing JDK:',

--- a/packages/cli/src/spec/mock/MockPrompt.ts
+++ b/packages/cli/src/spec/mock/MockPrompt.ts
@@ -110,4 +110,8 @@ export class MockPrompt implements Prompt {
     const nextResponse = this.responses.shift()!;
     return nextResponse;
   }
+
+  async downloadFile(): Promise<void> {
+    throw new Error('Not Implemented');
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,14 +15,12 @@
  */
 
 import {AndroidSdkTools} from './lib/androidSdk/AndroidSdkTools';
-import {AndroidSdkToolsInstaller} from './lib/androidSdk/AndroidSdkToolsInstaller';
 import {Config} from './lib/Config';
 import {GradleWrapper} from './lib/GradleWrapper';
 import {Log, ConsoleLog} from './lib/Log';
 import {MockLog} from './lib/mock/MockLog';
 import {JarSigner} from './lib/jdk/JarSigner';
 import {JdkHelper} from './lib/jdk/JdkHelper';
-import {JdkInstaller} from './lib/jdk/JdkInstaller';
 import {KeyTool} from './lib/jdk/KeyTool';
 import {TwaManifest, DisplayModes, DisplayMode, asDisplayMode, SigningKeyInfo}
   from './lib/TwaManifest';
@@ -31,14 +29,13 @@ import {DigitalAssetLinks} from './lib/DigitalAssetLinks';
 import * as util from './lib/util';
 import {Result} from './lib/Result';
 
-export {AndroidSdkTools,
-  AndroidSdkToolsInstaller,
+export {
+  AndroidSdkTools,
   Config,
   DigitalAssetLinks,
   GradleWrapper,
   JarSigner,
   JdkHelper,
-  JdkInstaller,
   KeyTool,
   Log,
   ConsoleLog,


### PR DESCRIPTION
- Moves JdkInstalled and AndroidSdkInstaller to `cli`, as apps
  using `core` should build their own configs.
- Displays a progress bar when downloading the JDK Sources, the
  JDK Binaries and the Android SDK.
- Displays messages when decompressing JDK Sources, JDK Binaries
  and the Android SDK.

<img width="1431" alt="Screen Shot 2020-11-03 at 19 46 41" src="https://user-images.githubusercontent.com/1733592/98033498-833aa980-1e0d-11eb-90b5-3338efba3a78.png">


Closes #349