### PR TITLE
Update abh-alpha to 2.1.0-alpha01

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -58,7 +58,6 @@ const DEFAULT_APP_VERSION_NAME = DEFAULT_APP_VERSION_CODE.toString();
 const DEFAULT_SIGNING_KEY_PATH = './android.keystore';
 const DEFAULT_SIGNING_KEY_ALIAS = 'android';
 const DEFAULT_ENABLE_NOTIFICATIONS = false;
-const DEFAULT_ENABLE_LOCATION = false;
 const DEFAULT_GENERATOR_APP_NAME = 'unknown';
 
 export type FallbackType = 'customtabs' | 'webview';
@@ -294,9 +293,7 @@ export class TwaManifest {
       enableNotifications: DEFAULT_ENABLE_NOTIFICATIONS,
       shortcuts: shortcuts,
       webManifestUrl: webManifestUrl.toString(),
-      features: {
-        locationDelegation: {enabled: DEFAULT_ENABLE_LOCATION},
-      },
+      features: {},
       // We're leaving `shareTarget` as undefined for now, as the shareTarget is not complete
       // and we want to avoid creating manifests with invalid values for now. The broader Web Share
       // Target implementation is being tracked at

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -19,6 +19,7 @@ import {AppsFlyerFeature} from './AppsFlyerFeature';
 import {LocationDelegationFeature} from './LocationDelegationFeature';
 import {TwaManifest} from '../TwaManifest';
 import {FirstRunFlagFeature} from './FirstRunFlagFeature';
+import {Log, ConsoleLog} from '../Log';
 
 /**
  * Analyzes a TwaManifest to collect enable features and aggregates all customizations that will
@@ -52,9 +53,14 @@ export class FeatureManager {
   /**
    * Builds a new intance from a TwaManifest.
    */
-  constructor(twaManifest: TwaManifest) {
+  constructor(twaManifest: TwaManifest, log: Log = new ConsoleLog('FeatureManager')) {
     if (twaManifest.features.locationDelegation?.enabled) {
-      this.addFeature(new LocationDelegationFeature());
+      if (twaManifest.alphaDependencies?.enabled) {
+        this.addFeature(new LocationDelegationFeature());
+      } else {
+        log.warn('Skipping LocationDelegationFeature. '+
+            'Enable alphaDependencies to add LocationDelegationFeature.');
+      }
     }
 
     if (twaManifest.features.appsFlyer?.enabled) {
@@ -72,7 +78,7 @@ export class FeatureManager {
 
     if (twaManifest.alphaDependencies?.enabled) {
       this.buildGradle.dependencies.add(
-          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0-alpha01');
     } else {
       this.buildGradle.dependencies.add(
           'com.google.androidbrowserhelper:androidbrowserhelper:2.0.1');

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -89,7 +89,7 @@ describe('FeatureManager', () => {
       } as TwaManifest;
       const features = new FeatureManager(manifest);
       expect(features.buildGradle.dependencies).toContain(
-          'com.google.androidbrowserhelper:androidbrowserhelper:1.4.0-alpha01');
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0-alpha01');
     });
 
     it('Adds INTERNET permission when WebView fallback is enabled', () => {
@@ -136,6 +136,9 @@ describe('FeatureManager', () => {
             enabled: true,
           },
         },
+        alphaDependencies: {
+          enabled: true,
+        },
       } as TwaManifest;
 
       const locationDelegationFeature = new LocationDelegationFeature();
@@ -151,6 +154,30 @@ describe('FeatureManager', () => {
 
       expect(features.delegationService.classConstructor!)
           .toContain(locationDelegationFeature.delegationService.classConstructor!);
+    });
+
+    it('LocationDelegation is not enabled without alphaDependencies', () => {
+      const manifest = {
+        features: {
+          locationDelegation: {
+            enabled: true,
+          },
+        },
+      } as TwaManifest;
+
+      const locationDelegationFeature = new LocationDelegationFeature();
+      const features = new FeatureManager(manifest);
+
+      locationDelegationFeature.androidManifest.components.forEach((component) => {
+        expect(features.androidManifest.components).not.toContain(component);
+      });
+
+      locationDelegationFeature.delegationService.imports.forEach((imp) => {
+        expect(features.delegationService.imports).not.toContain(imp);
+      });
+
+      expect(features.delegationService.classConstructor!)
+          .not.toContain(locationDelegationFeature.delegationService.classConstructor!);
     });
   });
 });


### PR DESCRIPTION
- Updates ABH version.
- `features` in TwaManifest defaults to an empty object.
- `LocationDelegationFeature` can only be enabled when
  `alphaDependencies` are enabled.