### PR TITLE
shareTarget derives full action URL

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -294,13 +294,28 @@ export class TwaManifest {
       shortcuts: shortcuts,
       webManifestUrl: webManifestUrl.toString(),
       features: {},
-      // We're leaving `shareTarget` as undefined for now, as the shareTarget is not complete
-      // and we want to avoid creating manifests with invalid values for now. The broader Web Share
-      // Target implementation is being tracked at
-      // https://github.com/GoogleChromeLabs/bubblewrap/issues/21.
-      shareTarget: undefined,
+      shareTarget: TwaManifest.verifyShareTarget(webManifestUrl, webManifest.share_target),
     });
     return twaManifest;
+  }
+
+  private static verifyShareTarget(
+      webManifestUrl: URL, shareTarget?: ShareTarget): ShareTarget | undefined {
+    if (!shareTarget || !shareTarget.action || !shareTarget.params || !shareTarget.params.files) {
+      return undefined;
+    }
+
+    for (const file of shareTarget.params.files) {
+      if (!file.accept) {
+        return undefined;
+      }
+    }
+
+    return {
+      ...shareTarget,
+      // Ensure action is an absolute URL.
+      action: new URL(shareTarget.action, webManifestUrl).toString(),
+    };
   }
 
   /**

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -301,7 +301,7 @@ export class TwaManifest {
 
   private static verifyShareTarget(
       webManifestUrl: URL, shareTarget?: ShareTarget): ShareTarget | undefined {
-    if (!shareTarget || !shareTarget.action || !shareTarget.params || !shareTarget.params.files) {
+    if (!shareTarget?.action || !shareTarget?.params?.files) {
       return undefined;
     }
 

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -121,9 +121,11 @@
                     <action android:name="android.intent.action.SEND" />
                     <action android:name="android.intent.action.SEND_MULTIPLE" />
                     <category android:name="android.intent.category.DEFAULT" />
-                    <data android:mimeType="audio/*" />
-                    <data android:mimeType="image/*" />
-                    <data android:mimeType="video/*" />
+                    <% for (const file of shareTarget.params.files) { %>
+                        <% for (const accept of file.accept) { %>
+                            <data android:mimeType="<%= accept %>" />
+                        <% } %>
+                    <% } %>
                 </intent-filter>
             <% } %>
 


### PR DESCRIPTION
- Derive the full action URL from the Web Manifest URL.
- Extracts mime-types from share-target.

Improves #21 