### PR TITLE
Handles orientation in twa-manifest.json, AndroidManifest.xml and init

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,6 +130,8 @@ bubblewrap init --manifest="<web-manifest-url>" [--directory="<path-to-output-lo
 Options:
   - `--directory`: path where to generate the project. Defaults to the current directory.
   - `--chromeosonly`: this flag specifies that the build will be used for Chrome OS only and prevents non-Chrome OS devices from installing the app.
+  - `--alphaDependencies`: enables features that depend on upcoming version of the Android library
+  for Trusted Web Activity or that are still unstable.
 
 ## `build`
 

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -18,7 +18,7 @@ import * as minimist from 'minimist';
 import {update} from './cmds/update';
 import {help} from './cmds/help';
 import {build} from './cmds/build';
-import {init} from './cmds/init';
+import {init, InitArgs} from './cmds/init';
 import {validate} from './cmds/validate';
 import {install} from './cmds/install';
 import {loadOrCreateConfig} from './config';
@@ -61,7 +61,7 @@ export class Cli {
       case 'help':
         return await help(parsedArgs);
       case 'init':
-        return await init(parsedArgs, config);
+        return await init(parsedArgs as unknown as InitArgs, config);
       case 'update':
         return await update(parsedArgs);
       case 'build':

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -44,8 +44,12 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         '',
         'Options:',
-        '--directory ......... path where to generate the project. Defaults to the current' +
+        '--directory ........... path where to generate the project. Defaults to the current' +
             ' directory',
+        '--chromeosonly ........ specifies that the build will be used for Chrome OS only and' +
+            ' prevents non-Chrome OS devices from installing the app.',
+        '--alphaDependencies ... enables features that depend on upcoming version of the ' +
+            ' Android library for Trusted Web Activity or that are still unstable.',
       ].join('\n')],
       ['build', [
         'Usage:',

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -79,6 +79,7 @@ async function confirmTwaConfig(twaManifest: TwaManifest, prompt: Prompt): Promi
       validateDisplayMode,
   );
 
+  // This feature is enabled with the --alphaDependencies flag.
   // TODO(andreban): Remove the alpha check when androidx.browser becomes stable.
   if (twaManifest.alphaDependencies) {
     twaManifest.orientation = await prompt.promptChoice(

--- a/packages/cli/src/lib/inputHelpers.ts
+++ b/packages/cli/src/lib/inputHelpers.ts
@@ -17,7 +17,8 @@
 import Color = require('color');
 import {URL} from 'url';
 import {isWebUri} from 'valid-url';
-import {Result, DisplayMode, asDisplayMode, util} from '@bubblewrap/core';
+import {Result, DisplayMode, asDisplayMode, asOrientation, Orientation, util}
+  from '@bubblewrap/core';
 import {ValidateFunction} from './Prompt';
 import {enUS as messages} from './strings';
 import {domainToASCII} from 'url';
@@ -204,6 +205,21 @@ export async function validateDisplayMode(input: string): Promise<Result<Display
     return Result.error(new Error(messages.errorInvalidDisplayMode(input)));
   }
   return Result.ok(displayMode);
+}
+
+/**
+ * A {@link ValidateFunction} that receives a {@link string} as input and resolves to a
+ * {@link Orientation} when successful.
+ * @param {string} input a string to be converted to a {@link Orientation}.
+ * @returns {Result<Orientation, Error>} a result that resolves to a {@link Orientation} on
+ * success or {@link Error} on failure.
+ */
+export async function validateOrientation(input: string): Promise<Result<Orientation, Error>> {
+  const orientation = asOrientation(input);
+  if (orientation === null) {
+    return Result.error(new Error(messages.errorInvalidOrientation(input)));
+  }
+  return Result.ok(orientation);
 }
 
 /**

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -21,10 +21,12 @@ type Messages = {
   errorFailedToRunQualityCriteria: string;
   errorMaxLength: (maxLength: number, actualLength: number) => string;
   errorMinLength: (minLength: number, actualLength: number) => string;
+  errorMissingManifestParameter: string;
   errorRequireHttps: string;
   errorInvalidUrl: (url: string) => string;
   errorInvalidColor: (color: string) => string;
   errorInvalidDisplayMode: (displayMode: string) => string;
+  errorInvalidOrientation: (orientation: string) => string;
   errorInvalidInteger: (integer: string) => string;
   errorUrlMustBeImage: (mimeType: string) => string;
   errorUrlMustNotBeSvg: string;
@@ -70,6 +72,7 @@ type Messages = {
   promptName: string;
   promptLauncherName: string;
   promptDisplayMode: string;
+  promptOrientation: string;
   promptThemeColor: string;
   promptBackgroundColor: string;
   promptStartUrl: string;
@@ -107,6 +110,7 @@ export const enUS: Messages = {
   errorMinLength: (minLength, actualLength): string => {
     return `Minimum length is ${minLength} but input is ${actualLength}.`;
   },
+  errorMissingManifestParameter: `Missing required parameter ${cyan('--manifest')}`,
   errorRequireHttps: 'Url must be https.',
   errorInvalidUrl: (url: string): string => {
     return `Invalid URL: ${url}`;
@@ -116,6 +120,9 @@ export const enUS: Messages = {
   },
   errorInvalidDisplayMode: (displayMode: string): string => {
     return `Invalid display mode: ${displayMode}`;
+  },
+  errorInvalidOrientation: (orientation: string): string => {
+    return `Invalid orientation: ${orientation}`;
   },
   errorInvalidInteger: (integer: string): string => {
     return `Invalid integer provided: ${integer}`;
@@ -266,6 +273,7 @@ the PWA:
   promptName: 'Application name:',
   promptLauncherName: 'Short name:',
   promptDisplayMode: 'Display mode:',
+  promptOrientation: 'Orientation:',
   promptThemeColor: 'Status bar color:',
   promptBackgroundColor: 'Splash screen color:',
   promptStartUrl: 'URL path:',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,8 +22,8 @@ import {MockLog} from './lib/mock/MockLog';
 import {JarSigner} from './lib/jdk/JarSigner';
 import {JdkHelper} from './lib/jdk/JdkHelper';
 import {KeyTool} from './lib/jdk/KeyTool';
-import {TwaManifest, DisplayModes, DisplayMode, asDisplayMode, SigningKeyInfo}
-  from './lib/TwaManifest';
+import {TwaManifest, DisplayModes, DisplayMode, asDisplayMode, Orientation, Orientations,
+  asOrientation, SigningKeyInfo} from './lib/TwaManifest';
 import {TwaGenerator} from './lib/TwaGenerator';
 import {DigitalAssetLinks} from './lib/DigitalAssetLinks';
 import * as util from './lib/util';
@@ -40,6 +40,9 @@ export {
   Log,
   ConsoleLog,
   MockLog,
+  Orientation,
+  Orientations,
+  asOrientation,
   TwaGenerator,
   TwaManifest,
   DisplayMode,

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -45,7 +45,9 @@ export function asDisplayMode(input: string): DisplayMode | null {
   return DISPLAY_MODE_VALUES.includes(input) ? input as DisplayMode : null;
 }
 
-const ORIENTATION_VALUES = ['any', 'natural', 'landscape', 'portrait', 'portrait-primary',
+// Possible values for screen orientation, as defined in `android-browser-helper`:
+// https://github.com/GoogleChrome/android-browser-helper/blob/alpha/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java#L191-L216
+const ORIENTATION_VALUES = ['default', 'any', 'natural', 'landscape', 'portrait', 'portrait-primary',
   'portrait-secondary', 'landscape-primary', 'landscape-secondary'];
 export type Orientation = typeof ORIENTATION_VALUES[number];
 export const Orientations: Orientation[] = [...ORIENTATION_VALUES];
@@ -71,7 +73,7 @@ const DEFAULT_SIGNING_KEY_PATH = './android.keystore';
 const DEFAULT_SIGNING_KEY_ALIAS = 'android';
 const DEFAULT_ENABLE_NOTIFICATIONS = false;
 const DEFAULT_GENERATOR_APP_NAME = 'unknown';
-const DEFAULT_ORIENTATION = 'any';
+const DEFAULT_ORIENTATION = 'default';
 
 export type FallbackType = 'customtabs' | 'webview';
 

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -45,6 +45,18 @@ export function asDisplayMode(input: string): DisplayMode | null {
   return DISPLAY_MODE_VALUES.includes(input) ? input as DisplayMode : null;
 }
 
+const ORIENTATION_VALUES = ['any', 'natural', 'landscape', 'portrait', 'portrait-primary',
+  'portrait-secondary', 'landscape-primary', 'landscape-secondary'];
+export type Orientation = typeof ORIENTATION_VALUES[number];
+export const Orientations: Orientation[] = [...ORIENTATION_VALUES];
+
+export function asOrientation(input?: string): Orientation | null {
+  if (!input) {
+    return null;
+  }
+  return ORIENTATION_VALUES.includes(input) ? input as Orientation : null;
+}
+
 // Default values used on the Twa Manifest
 const DEFAULT_SPLASHSCREEN_FADEOUT_DURATION = 300;
 const DEFAULT_APP_NAME = 'My TWA';
@@ -59,6 +71,7 @@ const DEFAULT_SIGNING_KEY_PATH = './android.keystore';
 const DEFAULT_SIGNING_KEY_ALIAS = 'android';
 const DEFAULT_ENABLE_NOTIFICATIONS = false;
 const DEFAULT_GENERATOR_APP_NAME = 'unknown';
+const DEFAULT_ORIENTATION = 'any';
 
 export type FallbackType = 'customtabs' | 'webview';
 
@@ -135,6 +148,7 @@ export class TwaManifest {
   enableSiteSettingsShortcut: boolean;
   isChromeOSOnly: boolean;
   shareTarget?: ShareTarget;
+  orientation: Orientation;
 
   private static log = new ConsoleLog('twa-manifest');
 
@@ -176,6 +190,7 @@ export class TwaManifest {
       data.enableSiteSettingsShortcut : true;
     this.isChromeOSOnly = data.isChromeOSOnly != undefined ? data.isChromeOSOnly : false;
     this.shareTarget = data.shareTarget;
+    this.orientation = data.orientation || DEFAULT_ORIENTATION;
   }
 
   /**
@@ -295,6 +310,7 @@ export class TwaManifest {
       webManifestUrl: webManifestUrl.toString(),
       features: {},
       shareTarget: TwaManifest.verifyShareTarget(webManifestUrl, webManifest.share_target),
+      orientation: asOrientation(webManifest.orientation) || DEFAULT_ORIENTATION,
     });
     return twaManifest;
   }
@@ -494,6 +510,7 @@ export interface TwaManifestJson {
   enableSiteSettingsShortcut?: boolean;
   isChromeOSOnly?: boolean;
   shareTarget?: ShareTarget;
+  orientation?: Orientation;
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -47,8 +47,8 @@ export function asDisplayMode(input: string): DisplayMode | null {
 
 // Possible values for screen orientation, as defined in `android-browser-helper`:
 // https://github.com/GoogleChrome/android-browser-helper/blob/alpha/androidbrowserhelper/src/main/java/com/google/androidbrowserhelper/trusted/LauncherActivityMetadata.java#L191-L216
-const ORIENTATION_VALUES = ['default', 'any', 'natural', 'landscape', 'portrait', 'portrait-primary',
-  'portrait-secondary', 'landscape-primary', 'landscape-secondary'];
+const ORIENTATION_VALUES = ['default', 'any', 'natural', 'landscape', 'portrait',
+  'portrait-primary', 'portrait-secondary', 'landscape-primary', 'landscape-secondary'];
 export type Orientation = typeof ORIENTATION_VALUES[number];
 export const Orientations: Orientation[] = [...ORIENTATION_VALUES];
 

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -27,6 +27,7 @@ describe('TwaManifest', () => {
         'short_name': 'PwaDirectory',
         'start_url': '/?utm_source=homescreen',
         'display': 'fullscreen',
+        'orientation': 'landscape',
         'icons': [{
           'src': '/favicons/android-chrome-192x192.png',
           'sizes': '192x192',
@@ -54,6 +55,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.name).toBe('PWA Directory');
       expect(twaManifest.launcherName).toBe('PwaDirectory');
       expect(twaManifest.display).toBe('fullscreen');
+      expect(twaManifest.orientation).toBe('landscape');
       expect(twaManifest.startUrl).toBe('/?utm_source=homescreen');
       expect(twaManifest.iconUrl)
           .toBe('https://pwa-directory.com/favicons/android-chrome-512x512.png');
@@ -97,6 +99,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.maskableIconUrl).toBeUndefined();
       expect(twaManifest.monochromeIconUrl).toBeUndefined();
       expect(twaManifest.display).toBe('standalone');
+      expect(twaManifest.orientation).toBe('any');
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.navigationColorDark.hex()).toBe('#000000');
@@ -196,6 +199,7 @@ describe('TwaManifest', () => {
         startUrl: '/',
         iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
         display: 'fullscreen',
+        orientation: 'landscape',
         themeColor: '#00ff00',
         navigationColor: '#000000',
         navigationColorDark: '#ffffff',
@@ -225,6 +229,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.startUrl).toEqual(twaManifest.startUrl);
       expect(twaManifest.iconUrl).toEqual(twaManifest.iconUrl);
       expect(twaManifest.display).toEqual('fullscreen');
+      expect(twaManifest.orientation).toEqual('landscape');
       expect(twaManifest.themeColor).toEqual(new Color('#00ff00'));
       expect(twaManifest.navigationColor).toEqual(new Color('#000000'));
       expect(twaManifest.navigationColorDark).toEqual(new Color('#ffffff'));

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -99,7 +99,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.maskableIconUrl).toBeUndefined();
       expect(twaManifest.monochromeIconUrl).toBeUndefined();
       expect(twaManifest.display).toBe('standalone');
-      expect(twaManifest.orientation).toBe('any');
+      expect(twaManifest.orientation).toBe('default');
       expect(twaManifest.themeColor.hex()).toBe('#FFFFFF');
       expect(twaManifest.navigationColor.hex()).toBe('#000000');
       expect(twaManifest.navigationColorDark.hex()).toBe('#000000');

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -44,6 +44,7 @@ def twaManifest = [
     // 'customtabs' and 'webview'.
     fallbackType: '<%= fallbackType %>',
     enableSiteSettingsShortcut: '<%= enableSiteSettingsShortcut %>',
+    orientation: '<%= orientation %>',
 ]
 
 android {
@@ -141,6 +142,7 @@ android {
         resValue "string", "fallbackType", twaManifest.fallbackType
 
         resValue "bool", "enableSiteSettingsShortcut", twaManifest.enableSiteSettingsShortcut
+        resValue "string", "orientation", twaManifest.orientation
     }
     buildTypes {
         release {

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -116,6 +116,9 @@
                 android:value="immersive" />
             <% } %>
 
+            <meta-data android:name="android.support.customtabs.trusted.SCREEN_ORIENTATION"
+                android:value="@string/orientation"/>
+
             <% if (shareTarget) { %>
                 <intent-filter>
                     <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
- Handles orientation in twa-manifest.json, AndroidManifest.xml and init
- Adds an `alphaDependencies` parameter to `init`.
- Prompt for orientation only happens when that's enabled.