### PR TITLE
Escapes commas in dname when generating the signing key

### DIFF
--- a/packages/core/src/lib/jdk/KeyTool.ts
+++ b/packages/core/src/lib/jdk/KeyTool.ts
@@ -72,8 +72,10 @@ export class KeyTool {
     const keytoolCmd = [
       'keytool',
       '-genkeypair',
-      `-dname "cn=${keyOptions.fullName}, ou=${keyOptions.organizationalUnit}, ` +
-          `o=${keyOptions.organization}, c=${keyOptions.country}"`,
+      `-dname "cn=${KeyTool.escapeDName(keyOptions.fullName)}, ` +
+          `ou=${KeyTool.escapeDName(keyOptions.organizationalUnit)}, ` +
+          `o=${KeyTool.escapeDName(keyOptions.organization)}, ` +
+          `c=${KeyTool.escapeDName(keyOptions.country)}"`,
       `-alias \"${keyOptions.alias}\"`,
       `-keypass \"${keyOptions.keypassword}\"`,
       `-keystore \"${keyOptions.path}\"`,
@@ -120,6 +122,13 @@ export class KeyTool {
   async keyInfo(keyOptions: KeyOptions): Promise<KeyInfo> {
     const rawKeyInfo = await this.list(keyOptions);
     return KeyTool.parseKeyInfo(rawKeyInfo);
+  }
+
+  /**
+   * The commas in the dname field from key tool must be escaped, so that 'te,st' becomes 'te\,st'.
+   */
+  private static escapeDName(input: string): string {
+    return input.replace(/,/g, '\\,');
   }
 
   /**

--- a/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
+++ b/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
@@ -58,9 +58,9 @@ describe('KeyTool', () => {
       alias: 'keyalias',
       keypassword: 'keypass',
       password: 'pass',
-      fullName: 'Test User',
-      organization: 'Test Organization',
-      organizationalUnit: 'Testers',
+      fullName: 'Test, User',
+      organization: 'Test, Organization',
+      organizationalUnit: 'Tes,ters',
       country: 'GB',
     } as CreateKeyOptions;
 
@@ -72,7 +72,7 @@ describe('KeyTool', () => {
       expect(util.execute).toHaveBeenCalledWith([
         'keytool',
         '-genkeypair',
-        `-dname "cn=${keyOptions.fullName}, ou=${keyOptions.organizationalUnit}, ` +
+        `-dname "cn=Test\\, User, ou=Test, Organization, ` +
             `o=${keyOptions.organization}, c=${keyOptions.country}"`,
         `-alias "${keyOptions.alias}"`,
         `-keypass "${keyOptions.keypassword}"`,

--- a/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
+++ b/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
@@ -72,8 +72,8 @@ describe('KeyTool', () => {
       expect(util.execute).toHaveBeenCalledWith([
         'keytool',
         '-genkeypair',
-        `-dname "cn=Test\\, User, ou=Test, Organization, ` +
-            `o=${keyOptions.organization}, c=${keyOptions.country}"`,
+        '-dname "cn=Test\\, User, ou=Tes\\,ters, ' +
+            `o=Test\\, Organization, c=${keyOptions.country}"`,
         `-alias "${keyOptions.alias}"`,
         `-keypass "${keyOptions.keypassword}"`,
         `-keystore "${keyOptions.path}"`,


### PR DESCRIPTION
See https://stackoverflow.com/questions/11808391/keytool-error-java-io-ioexceptionincorrect-ava-format

Closes #373 