### PR TITLE
Rename classConstructor to onCreate.

### DIFF
--- a/packages/core/src/lib/features/EmptyFeature.ts
+++ b/packages/core/src/lib/features/EmptyFeature.ts
@@ -56,7 +56,7 @@ export class EmptyFeature implements Feature {
 
   delegationService: {
     imports: string[];
-    classConstructor?: string;
+    onCreate?: string;
   } = {
     imports: new Array<string>(),
   };

--- a/packages/core/src/lib/features/Feature.ts
+++ b/packages/core/src/lib/features/Feature.ts
@@ -129,9 +129,9 @@ export interface Feature {
      */
     imports: string[];
     /**
-     * Code segment to be added to the constructor. The code will be called
+     * Code segment to be added to onCreate. The code will be called by each plugin.
      * by each plugin.
      */
-    classConstructor?: string;
+    onCreate?: string;
   };
 }

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -48,7 +48,7 @@ export class FeatureManager {
   };
   delegationService = {
     imports: new Set<string>(),
-    classConstructor: new Array<string>(),
+    onCreate: new Array<string>(),
   };
 
   /**
@@ -145,8 +145,8 @@ export class FeatureManager {
       this.delegationService.imports.add(imp);
     });
 
-    if (feature.delegationService.classConstructor) {
-      this.delegationService.classConstructor.push(feature.delegationService.classConstructor);
+    if (feature.delegationService.onCreate) {
+      this.delegationService.onCreate.push(feature.delegationService.onCreate);
     }
   }
 }

--- a/packages/core/src/lib/features/LocationDelegationFeature.ts
+++ b/packages/core/src/lib/features/LocationDelegationFeature.ts
@@ -30,7 +30,7 @@ export class LocationDelegationFeature extends EmptyFeature {
 
     this.delegationService.imports.push('com.google.androidbrowserhelper.locationdelegation' +
         '.LocationDelegationExtraCommandHandler');
-    this.delegationService.classConstructor =
+    this.delegationService.onCreate =
         'registerExtraCommandHandler(new LocationDelegationExtraCommandHandler());';
   }
 }

--- a/packages/core/src/lib/features/PlayBillingFeature.ts
+++ b/packages/core/src/lib/features/PlayBillingFeature.ts
@@ -53,7 +53,7 @@ export class PlayBillingFeature extends EmptyFeature {
 
     this.delegationService.imports.push(
         'com.google.androidbrowserhelper.playbilling.digitalgoods.DigitalGoodsRequestHandler');
-    this.delegationService.classConstructor =
+    this.delegationService.onCreate =
         'registerExtraCommandHandler(new DigitalGoodsRequestHandler(getApplicationContext()));';
   }
 }

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -79,7 +79,7 @@ describe('FeatureManager', () => {
       expect(features.buildGradle.repositories).toEqual(emptySet);
       expect(features.launcherActivity.imports).toEqual(emptySet);
       expect(features.launcherActivity.launchUrl).toEqual([]);
-      expect(features.delegationService.classConstructor).toEqual([]);
+      expect(features.delegationService.onCreate).toEqual([]);
     });
 
     it('Creates from empty features with alpha features enabled', () => {
@@ -153,8 +153,8 @@ describe('FeatureManager', () => {
         expect(features.delegationService.imports).toContain(imp);
       });
 
-      expect(features.delegationService.classConstructor!)
-          .toContain(locationDelegationFeature.delegationService.classConstructor!);
+      expect(features.delegationService.onCreate!)
+          .toContain(locationDelegationFeature.delegationService.onCreate!);
     });
 
     it('LocationDelegation is not enabled without alphaDependencies', () => {
@@ -177,8 +177,8 @@ describe('FeatureManager', () => {
         expect(features.delegationService.imports).not.toContain(imp);
       });
 
-      expect(features.delegationService.classConstructor!)
-          .not.toContain(locationDelegationFeature.delegationService.classConstructor!);
+      expect(features.delegationService.onCreate!)
+          .not.toContain(locationDelegationFeature.delegationService.onCreate!);
     });
 
     it('Enables the Play Billing feature', () => {
@@ -204,8 +204,8 @@ describe('FeatureManager', () => {
         expect(features.delegationService.imports).toContain(imp);
       });
 
-      expect(features.delegationService.classConstructor!)
-          .toContain(playBillingFeature.delegationService.classConstructor!);
+      expect(features.delegationService.onCreate!)
+          .toContain(playBillingFeature.delegationService.onCreate!);
     });
   });
 });

--- a/packages/core/template_project/app/src/main/java/DelegationService.java
+++ b/packages/core/template_project/app/src/main/java/DelegationService.java
@@ -10,7 +10,7 @@ public class DelegationService extends
     public void onCreate() {
         super.onCreate();
 
-        <% for(const code of delegationService.classConstructor) { %>
+        <% for(const code of delegationService.onCreate) { %>
             <%= code %>
         <% } %>
     }


### PR DESCRIPTION
This PR follows up from #410 and makes the variable name a bit more apt.