### PR TITLE
Add BufferedLog and use it when generating the TWA.

### DIFF
--- a/packages/cli/src/lib/cmds/shared.ts
+++ b/packages/cli/src/lib/cmds/shared.ts
@@ -17,6 +17,7 @@
 import {InquirerPrompt, Prompt} from '../Prompt';
 import {enUS as messages} from '../strings';
 import {Presets, Bar} from 'cli-progress';
+import {BufferedLog, ConsoleLog} from '@bubblewrap/core';
 import {TwaGenerator, TwaManifest} from '@bubblewrap/core';
 import {green} from 'colors';
 import {createValidateString} from '../inputHelpers';
@@ -34,8 +35,10 @@ export async function generateTwaProject(prompt: Prompt, twaGenerator: TwaGenera
   const progress = (current: number, total: number): void => {
     progressBar.update(current / total * 100);
   };
-  await twaGenerator.createTwaProject(targetDirectory, twaManifest, progress);
+  const log = new BufferedLog(new ConsoleLog("Generating TWA"));
+  await twaGenerator.createTwaProject(targetDirectory, twaManifest, log, progress);
   progressBar.stop();
+  log.flush();
 }
 
 /**

--- a/packages/cli/src/lib/cmds/shared.ts
+++ b/packages/cli/src/lib/cmds/shared.ts
@@ -35,7 +35,7 @@ export async function generateTwaProject(prompt: Prompt, twaGenerator: TwaGenera
   const progress = (current: number, total: number): void => {
     progressBar.update(current / total * 100);
   };
-  const log = new BufferedLog(new ConsoleLog("Generating TWA"));
+  const log = new BufferedLog(new ConsoleLog('Generating TWA'));
   await twaGenerator.createTwaProject(targetDirectory, twaManifest, log, progress);
   progressBar.stop();
   log.flush();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 import {AndroidSdkTools} from './lib/androidSdk/AndroidSdkTools';
+import {BufferedLog} from './lib/BufferedLog';
 import {Config} from './lib/Config';
 import {GradleWrapper} from './lib/GradleWrapper';
 import {Log, ConsoleLog} from './lib/Log';
@@ -31,6 +32,7 @@ import {Result} from './lib/Result';
 
 export {
   AndroidSdkTools,
+  BufferedLog,
   Config,
   DigitalAssetLinks,
   GradleWrapper,

--- a/packages/core/src/lib/BufferedLog.ts
+++ b/packages/core/src/lib/BufferedLog.ts
@@ -23,13 +23,14 @@ enum LogLevel {
   Error,
 }
 
+/** Data class to store level and message of pending */
 class PendingLog {
   constructor(public level: LogLevel, public message: string) {}
 }
 
 /**
  * A Log that wraps another Log, saving up all the log calls to be applied when flush is called.
- * 
+ *
  * It doesn't currently support arguments to the log messages.
  */
 export class BufferedLog implements Log {
@@ -37,16 +38,18 @@ export class BufferedLog implements Log {
 
   constructor(private innerLog: Log) {}
 
+  /* eslint-disable no-invalid-this */
   debug = this.addLogFunction(LogLevel.Debug);
   info = this.addLogFunction(LogLevel.Info);
   warn = this.addLogFunction(LogLevel.Warn);
   error = this.addLogFunction(LogLevel.Error);
+  /* eslint-enable no-invalid-this */
 
   /** Creates a function that adds a log at the given level. */
   private addLogFunction(level: LogLevel): (message: string) => void {
-    return (message: string) => {
+    return (message: string): void => {
       this.pendingLogs.push(new PendingLog(level, message));
-    }
+    };
   }
 
   setVerbose(verbose: boolean): void {
@@ -55,21 +58,21 @@ export class BufferedLog implements Log {
 
   /** Flushes all recorded logs to the underlying object. */
   flush(): void {
-    this.pendingLogs.forEach(pendingLog => {
+    this.pendingLogs.forEach((pendingLog) => {
       const message = pendingLog.message;
 
       switch (pendingLog.level) {
         case LogLevel.Debug:
-          this.innerLog.debug(message)
+          this.innerLog.debug(message);
           break;
         case LogLevel.Info:
-          this.innerLog.info(message)
+          this.innerLog.info(message);
           break;
         case LogLevel.Warn:
-          this.innerLog.warn(message)
+          this.innerLog.warn(message);
           break;
         case LogLevel.Error:
-          this.innerLog.error(message)
+          this.innerLog.error(message);
           break;
       }
     });

--- a/packages/core/src/lib/BufferedLog.ts
+++ b/packages/core/src/lib/BufferedLog.ts
@@ -38,6 +38,9 @@ export class BufferedLog implements Log {
 
   constructor(private innerLog: Log) {}
 
+  // The "no-invalid-this" triggers incorrectly on the below code, see:
+  // https://github.com/eslint/eslint/issues/13894
+  // https://github.com/typescript-eslint/typescript-eslint/issues/2840
   /* eslint-disable no-invalid-this */
   debug = this.addLogFunction(LogLevel.Debug);
   info = this.addLogFunction(LogLevel.Info);

--- a/packages/core/src/lib/BufferedLog.ts
+++ b/packages/core/src/lib/BufferedLog.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {Log} from './Log';
+
+enum LogLevel {
+  Debug,
+  Info,
+  Warn,
+  Error,
+}
+
+class PendingLog {
+  constructor(public level: LogLevel, public message: string) {}
+}
+
+/**
+ * A Log that wraps another Log, saving up all the log calls to be applied when flush is called.
+ * 
+ * It doesn't currently support arguments to the log messages.
+ */
+export class BufferedLog implements Log {
+  private pendingLogs: Array<PendingLog> = [];
+
+  constructor(private innerLog: Log) {}
+
+  debug = this.addLogFunction(LogLevel.Debug);
+  info = this.addLogFunction(LogLevel.Info);
+  warn = this.addLogFunction(LogLevel.Warn);
+  error = this.addLogFunction(LogLevel.Error);
+
+  /** Creates a function that adds a log at the given level. */
+  private addLogFunction(level: LogLevel): (message: string) => void {
+    return (message: string) => {
+      this.pendingLogs.push(new PendingLog(level, message));
+    }
+  }
+
+  setVerbose(verbose: boolean): void {
+    this.innerLog.setVerbose(verbose);
+  }
+
+  /** Flushes all recorded logs to the underlying object. */
+  flush(): void {
+    this.pendingLogs.forEach(pendingLog => {
+      const message = pendingLog.message;
+
+      switch (pendingLog.level) {
+        case LogLevel.Debug:
+          this.innerLog.debug(message)
+          break;
+        case LogLevel.Info:
+          this.innerLog.info(message)
+          break;
+        case LogLevel.Warn:
+          this.innerLog.warn(message)
+          break;
+        case LogLevel.Error:
+          this.innerLog.error(message)
+          break;
+      }
+    });
+
+    this.pendingLogs = [];
+  }
+}

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -21,7 +21,7 @@ import {template} from 'lodash';
 import {promisify} from 'util';
 import {TwaManifest} from './TwaManifest';
 import {ShortcutInfo} from './ShortcutInfo';
-import {Log, ConsoleLog} from './Log';
+import {Log} from './Log';
 import {ImageHelper, IconDefinition} from './ImageHelper';
 import {FeatureManager} from './features/FeatureManager';
 import {rmdir, escapeJsonString, toAndroidScreenOrientation} from './util';
@@ -178,8 +178,6 @@ class Progress {
 export class TwaGenerator {
   private imageHelper = new ImageHelper();
 
-  constructor(private log: Log = new ConsoleLog('twa-generator')) {}
-
   // Ensures targetDir exists and copies a file from sourceDir to target dir.
   private async copyStaticFile(
       sourceDir: string, targetDir: string, filename: string): Promise<void> {
@@ -328,9 +326,9 @@ export class TwaGenerator {
    * @param {String} targetDirectory the directory where the project will be created
    * @param {Object} twaManifest configurations values for the project.
    */
-  async createTwaProject(targetDirectory: string, twaManifest: TwaManifest,
+  async createTwaProject(targetDirectory: string, twaManifest: TwaManifest, log: Log,
       reportProgress: twaGeneratorProgress = noOpProgress): Promise<void> {
-    const features = new FeatureManager(twaManifest);
+    const features = new FeatureManager(twaManifest, log);
     const progress = new Progress(9, reportProgress);
     const error = twaManifest.validate();
     if (error !== null) {

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -59,7 +59,7 @@ export class FeatureManager {
       if (twaManifest.alphaDependencies?.enabled) {
         this.addFeature(new LocationDelegationFeature());
       } else {
-        log.warn('Skipping LocationDelegationFeature. '+
+        log.error('Skipping LocationDelegationFeature. '+
             'Enable alphaDependencies to add LocationDelegationFeature.');
       }
     }
@@ -68,7 +68,7 @@ export class FeatureManager {
       if (twaManifest.alphaDependencies?.enabled) {
         this.addFeature(new PlayBillingFeature());
       } else {
-        log.warn('Skipping PlayBillingFeature. '+
+        log.error('Skipping PlayBillingFeature. '+
             'Enable alphaDependencies to add PlayBillingFeature.');
       }
     }

--- a/packages/core/src/spec/lib/BufferedLogSpec.ts
+++ b/packages/core/src/spec/lib/BufferedLogSpec.ts
@@ -22,10 +22,10 @@ describe('buffered log', () => {
     const mockLog = new MockLog();
     const bufferedLog = new BufferedLog(mockLog);
 
-    bufferedLog.debug("1");
-    bufferedLog.info("2");
-    bufferedLog.warn("3");
-    bufferedLog.error("4");
+    bufferedLog.debug('1');
+    bufferedLog.info('2');
+    bufferedLog.warn('3');
+    bufferedLog.error('4');
 
     expect(mockLog.getReceivedData()).toEqual([]);
   });
@@ -34,13 +34,13 @@ describe('buffered log', () => {
     const mockLog = new MockLog();
     const bufferedLog = new BufferedLog(mockLog);
 
-    bufferedLog.debug("1");
-    bufferedLog.info("2");
-    bufferedLog.warn("3");
-    bufferedLog.error("4");
+    bufferedLog.debug('1');
+    bufferedLog.info('2');
+    bufferedLog.warn('3');
+    bufferedLog.error('4');
 
     bufferedLog.flush();
 
-    expect(mockLog.getReceivedData()).toEqual(["1", "2", "3", "4"]);
-  })
-})
+    expect(mockLog.getReceivedData()).toEqual(['1', '2', '3', '4']);
+  });
+});

--- a/packages/core/src/spec/lib/BufferedLogSpec.ts
+++ b/packages/core/src/spec/lib/BufferedLogSpec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {BufferedLog} from '../../lib/BufferedLog';
+import {MockLog} from '../../lib/mock/MockLog';
+
+describe('buffered log', () => {
+  it('Prints nothing before flush', () => {
+    const mockLog = new MockLog();
+    const bufferedLog = new BufferedLog(mockLog);
+
+    bufferedLog.debug("1");
+    bufferedLog.info("2");
+    bufferedLog.warn("3");
+    bufferedLog.error("4");
+
+    expect(mockLog.getReceivedData()).toEqual([]);
+  });
+
+  it('Prints logs after flush', () => {
+    const mockLog = new MockLog();
+    const bufferedLog = new BufferedLog(mockLog);
+
+    bufferedLog.debug("1");
+    bufferedLog.info("2");
+    bufferedLog.warn("3");
+    bufferedLog.error("4");
+
+    bufferedLog.flush();
+
+    expect(mockLog.getReceivedData()).toEqual(["1", "2", "3", "4"]);
+  })
+})


### PR DESCRIPTION
This PR adds the `BufferedLog` class, a log that wraps another log and delays calls to any of the logging methods until `flush` is called.

This is used when we want to log something while showing a progress bar. If we logged while showing a progress bar we'll get mess output (Issue #416). Now we can buffer all the log messages until the progress bar has finished.

It also changes the warning presented when the user is trying to build with location delegation and play billing, but not with alpha dependencies into an error. In a follow up PR I'll add a check to ensure `enableNotifications` is `true`. I also believe that we should make the bubblewrap return code be non-zero as well.