### PR TITLE
Generate config and keys on the correct directory

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from 'fs';
+import {join, resolve} from 'path';
 import {Config, DisplayModes, JdkHelper, KeyTool, Orientations, TwaGenerator, TwaManifest}
   from '@bubblewrap/core';
 import {validateHost, validateColor, createValidateString, validateDisplayMode, validatePackageId,
@@ -203,6 +204,17 @@ export async function init(
     return false;
   }
   prompt.printMessage(messages.messageInitializingWebManifest(args.manifest));
+  // Ensure `targetDirectory` exists.
+  const targetDirectory = resolve(process.cwd(), args.directory || './');
+  if (!fs.existsSync(targetDirectory)) {
+    // Confirm if the directory should be created. Otherwise, thrown an error.
+    if (!await prompt.promptConfirm(
+        messages.promptCreateDirectory(targetDirectory), true)) {
+      throw new Error(messages.errorDirectoryDoesNotExist(targetDirectory));
+    }
+    fs.promises.mkdir(targetDirectory, {recursive: true});
+  }
+
   let twaManifest = await TwaManifest.fromWebManifest(args.manifest);
   if (args.chromeosonly) {
     twaManifest.isChromeOSOnly = true;
@@ -214,10 +226,11 @@ export async function init(
     };
   }
 
+  // The default path is "./android-keystore". Make sure it's relative to "targetDirectory".
+  twaManifest.signingKey.path = join(targetDirectory, twaManifest.signingKey.path);
   twaManifest = await confirmTwaConfig(twaManifest, prompt);
   const twaGenerator = new TwaGenerator();
-  const targetDirectory = args.directory || process.cwd();
-  await twaManifest.saveToFile('./twa-manifest.json');
+  await twaManifest.saveToFile(join(targetDirectory, '/twa-manifest.json'));
   await generateTwaProject(prompt, twaGenerator, targetDirectory, twaManifest);
   await createSigningKey(twaManifest, config, prompt);
   prompt.printMessage(messages.messageProjectGeneratedSuccess);

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -18,6 +18,7 @@ import {cyan, green, underline, bold, italic, red, yellow} from 'colors';
 
 type Messages = {
   errorAssetLinksGeneration: string;
+  errorDirectoryDoesNotExist: (directory: string) => string;
   errorFailedToRunQualityCriteria: string;
   errorMaxLength: (maxLength: number, actualLength: number) => string;
   errorMinLength: (minLength: number, actualLength: number) => string;
@@ -63,6 +64,7 @@ type Messages = {
   messageDecompressJdkBin: string;
   messageDownloadAndroidSdk: string;
   messageDecompressAndroidSdk: string;
+  promptCreateDirectory: (directory: string) => string;
   promptInstallJdk: string;
   promptJdkPath: string;
   promptInstallSdk: string;
@@ -102,6 +104,9 @@ type Messages = {
 
 export const enUS: Messages = {
   errorAssetLinksGeneration: 'Error generating "assetlinks.json"',
+  errorDirectoryDoesNotExist: (directory: string): string => {
+    return `Cannot write to directory: ${directory}.`;
+  },
   errorFailedToRunQualityCriteria:
       yellow('\nFailed to run the PWA Quality Criteria checks. Skipping.'),
   errorMaxLength: (maxLength, actualLength): string => {
@@ -262,6 +267,9 @@ the PWA:
   messageDecompressJdkBin: 'Decompressing the JDK 8 Binaries...',
   messageDownloadAndroidSdk: 'Downloading the Android SDK...',
   messageDecompressAndroidSdk: 'Decompressing the Android SDK...',
+  promptCreateDirectory: (directory: string): string => {
+    return `Directory ${cyan(directory)} does not exist. Do you want to create it now?`;
+  },
   promptInstallJdk: `Do you want Bubblewrap to install JDK?
   (Enter "No" to use your JDK installation)`,
   promptJdkPath: 'Path to your existing JDK:',


### PR DESCRIPTION
- When running `init` with the `--directory` option,
  `twa-manifest.json` was generated in the current directory
  instead of the project directory.
- The `init` method would also suggest the current directory as
  the default for the keystore. This is changed to be inside the
  target directory.

Closes #414