### PR TITLE
Fixes installation loop

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -103,6 +103,7 @@ export async function untar(
   await extractTar({
     file: tarFile,
     cwd: destinationPath,
+    unlink: true,
   });
   if (deleteZipWhenDone) {
     fs.unlinkSync(tarFile);


### PR DESCRIPTION
The loop is caused by `untar` failing due to the files already
existing on the system. We set `unlink: true` so existing
files are overwritten.

A couple of related issues for other PRs:

- Error message is not being displayed.
- If Android SDK installation fails we shouldn't reinstall the JDK.
So, those states need to be handled separately.

Closes #428 