### PR TITLE
Disable gradle lint when building Android project

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -153,6 +153,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    lintOptions {
+        checkReleaseBuilds false
+    }
 }
 
 task generateShorcutsFile {


### PR DESCRIPTION
`gradle assembleRelease` is reporting "Instantiable" errors like:
 - Application must extend android.app.Application
 - ManageDataLauncherActivity must extend android.app.Activity
 - FileProvider must extend android.content.ContentProvider
 - DelegationService must extend android.app.Service

Disabling the linter temporarily, as the code is correct and until
disabling / working around specific errors.

Full report:
```
> Task :app:lintVitalRelease FAILED
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:30: Error: Application must extend android.app.Application [Instantiatable]
        android:name="Application"
                      ~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:55: Error: ManageDataLauncherActivity must extend android.app.Activity [Instantiatable]
            <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:62: Error: LauncherActivity must extend android.app.Activity [Instantiatable]
        <activity android:name="LauncherActivity"
                                ~~~~~~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:129: Error: FocusActivity must extend android.app.Activity [Instantiatable]
        <activity android:name="com.google.androidbrowserhelper.trusted.FocusActivity" />
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:131: Error: WebViewFallbackActivity must extend android.app.Activity [Instantiatable]
        <activity android:name="com.google.androidbrowserhelper.trusted.WebViewFallbackActivity"
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:135: Error: FileProvider must extend android.content.ContentProvider [Instantiatable]
            android:name="androidx.core.content.FileProvider"
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\Projects\twa-project\app\src\main\AndroidManifest.xml:145: Error: DelegationService must extend android.app.Service [Instantiatable]
            android:name=".DelegationService"

   Explanation for issues of type "Instantiatable":
   Activities, services, broadcast receivers etc. registered in the manifest
   file (or for custom views, in a layout file) must be "instantiatable" by
   the system, which means that the class must be public, it must have an
   empty public constructor, and if it's an inner class, it must be a static
   inner class.

7 errors, 0 warnings

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintVitalRelease'.
> Lint found fatal errors while assembling a release target.

  To proceed, either fix the issues identified by lint, or modify your build script as follows:
  ...
  android {
      lintOptions {
          checkReleaseBuilds false
          // Or, if you prefer, you can continue to check for errors in release builds,
          // but continue the build even when errors are found:
          abortOnError false
      }
  }
  ...

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
13 actionable tasks: 1 executed, 12 up-to-date
```