### PR TITLE
Fixes Web Share for both text/plain and files

### DIFF
--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -344,13 +344,17 @@ export class TwaGenerator {
       mimeTypes: [],
     };
 
+    if (twaManifest.shareTarget?.params?.url ||
+        twaManifest.shareTarget?.params?.title ||
+        twaManifest.shareTarget?.params?.text) {
+      shareTargetIntentFilter.mimeTypes.push('text/plain');
+    }
+
     if (twaManifest.shareTarget?.params?.files) {
       shareTargetIntentFilter.actions.push('android.intent.action.SEND_MULTIPLE');
       for (const file of twaManifest.shareTarget.params.files) {
         file.accept.forEach((accept) => shareTargetIntentFilter.mimeTypes.push(accept));
       }
-    } else {
-      shareTargetIntentFilter.mimeTypes.push('text/plain');
     }
     return shareTargetIntentFilter;
   }


### PR DESCRIPTION
- When the shareTarget element contains both text/url/title and
  the files element, add "text/plain" and the mime-types from
  the files.

Should fix #451 