### PR TITLE
Separate build and sign steps for buildApk and buildAppBundles

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -26,13 +26,17 @@ import {ParsedArgs} from 'minimist';
 import {createValidateString} from '../inputHelpers';
 
 // Path to the file generated when building an app bundle file using gradle.
-const APP_BUNDLE_BUILD_OUTPUT_FILE_NAME = 'app/build/outputs/bundle/release/app-release.aab';
+const APP_BUNDLE_BUILD_OUTPUT_FILE_NAME = './app/build/outputs/bundle/release/app-release.aab';
 const APP_BUNDLE_SIGNED_FILE_NAME = './app-release-bundle.aab'; // Final signed App Bundle file.
 
 // Path to the file generated when building an APK file using gradle.
 const APK_BUILD_OUTPUT_FILE_NAME = './app/build/outputs/apk/release/app-release-unsigned.apk';
-const APK_SIGNED_FILE_NAME = './app-release-signed.apk'; // Final aligned and signed APK.
-const APK_ALIGNED_FILE_NAME = './app-release-unsigned-aligned.apk'; // Output file for zipalign.
+
+// Final aligned and signed APK.
+const APK_SIGNED_FILE_NAME = './app-release-signed.apk';
+
+// Output file for zipalign.
+const APK_ALIGNED_FILE_NAME = './app-release-unsigned-aligned.apk';
 
 const TWA_MANIFEST_FILE_NAME = './twa-manifest.json';
 const ASSETLINKS_OUTPUT_FILE = './assetlinks.json';


### PR DESCRIPTION
- Developers reported the need to generate "unsigned" APKs and
  Bundles, as signing packages is sometimes generated as part of
  a CI or by different teams (see #413).
- This PR splits build and signing steps into two methods and paves
  the way for a next PR that will enable passing a parameter to
  skip the signing step.
- We also move constant file names to `consts`.