### PR TITLE
Add --manifest option for build script

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,11 +113,12 @@ Set `BUBBLEWRAP_KEYSTORE_PASSWORD` for the key store password and `BUBBLEWRAP_KE
 Usage:
 
 ```
-bubblewrap build [--skipPwaValidation]
+bubblewrap build [--skipPwaValidation] [--manifest="<path-twa-manifest>"]
 ```
 
 Options: 
   - `--skipPwaValidation`: skips validating the wrapped PWA against the Quality Criteria.
+  - `--manifest`: directory where the client should look for `twa-manifest.json`.
 
 
 ## `update`

--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -93,7 +93,7 @@ class Build {
 
   async runValidation(): Promise<Result<PwaValidationResult, Error>> {
     try {
-      const manifestFile = path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
+      const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
       const twaManifest = await TwaManifest.fromFile(manifestFile);
       const pwaValidationResult =
           await PwaValidator.validate(new URL(twaManifest.startUrl, twaManifest.webManifestUrl));
@@ -170,7 +170,8 @@ class Build {
       validationPromise = this.runValidation();
     }
 
-    const twaManifest = await TwaManifest.fromFile(TWA_MANIFEST_FILE_NAME);
+    const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
+    const twaManifest = await TwaManifest.fromFile(manifestFile);
     const passwords = await this.getPasswords(twaManifest.signingKey);
 
     // Builds the Android Studio Project

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -60,6 +60,7 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         'Options:',
         '--skipPwaValidation ....... skips validating the wrapped PWA against the Quality Criteria',
+        '--manifest ................ directory where the client should look for twa-manifest.json',
       ].join('\n')],
       ['update', [
         'Usage:',


### PR DESCRIPTION
**Problem:** The directory with our `twa-manifest.json` and the directory we're running the Bubblewrap commands from are different.

**Solution:** Add a `--manifest` option to the `bubblewrap build` command which allows the user to specify a directory where the client should look for `twa-manifest.json`, much like that option for the `bubblewrap update` command.