### PR TITLE
Add --skipSigning option to build command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,11 +113,12 @@ Set `BUBBLEWRAP_KEYSTORE_PASSWORD` for the key store password and `BUBBLEWRAP_KE
 Usage:
 
 ```
-bubblewrap build [--skipPwaValidation]
+bubblewrap build [--skipPwaValidation] [--skipSigning]
 ```
 
 Options: 
   - `--skipPwaValidation`: skips validating the wrapped PWA against the Quality Criteria.
+  - `--skipSigning`: skips signing the built APK and App Bundle.
 
 
 ## `update`

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -60,6 +60,7 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         'Options:',
         '--skipPwaValidation ....... skips validating the wrapped PWA against the Quality Criteria',
+        '--skipSigning ............. skips signing the built APK and App Bundle',
       ].join('\n')],
       ['update', [
         'Usage:',

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -35,7 +35,7 @@ type Messages = {
   messageInitializingWebManifest: (manifestUrl: string) => string;
   messageAndroidAppDetails: string;
   messageAndroidAppDetailsDesc: string;
-  messageApkSucess: (filename: string) => string;
+  messageApkSuccess: (filename: string) => string;
   messageAppBundleSuccess: (filename: string) => string;
   messageBuildingApp: string;
   messageDigitalAssetLinksSuccess: (filename: string) => string;
@@ -165,7 +165,7 @@ into a device:
 
 \t- ${bold('Status bar color:')} sets the status bar color used when the
 \t  application is in foreground. Example: ${cyan('#7CC0FF')}\n`,
-  messageApkSucess: (filename: string): string => {
+  messageApkSuccess: (filename: string): string => {
     return `\t- Generated Android APK at ${cyan(filename)}`;
   },
   messageAppBundleSuccess: (filename: string): string => {


### PR DESCRIPTION
**Problem:** In our use case, we have to upload our unsigned APK/App Bundle to another service to be signed by people with the correct internal permissions for signing Android apps.

**Solution:** Add a `--skipSigning` option to the `bubblewrap build` command so that we can get an unsigned, built APK/App Bundle as output with a successful exit code.