### PR TITLE
Allow skip version upgrade and setting version name on merge

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,6 +211,8 @@ bubblewrap merge --ignore [fields-list]
 ```
 
 Options:
+  - `--appVersionName`: version name to be used on on the upgrade. Ignored if `--skipVersionUpgrade` is used.
+  - `--skipVersionUpgrade`: skips upgrading `appVersion` and `appVersionCode`.
   - `--ignore`: Ignores all of the fields on the list. Accepts all of the possible fields
   in the Web Manifest.
 

--- a/packages/cli/src/lib/cmds/help.ts
+++ b/packages/cli/src/lib/cmds/help.ts
@@ -119,6 +119,9 @@ const HELP_MESSAGES = new Map<string, string>(
         '',
         '',
         'Options: ',
+        '--appVersionName ........... version name to be used on on the upgrade. Ignored if ' +
+            '--skipVersionUpgrade is used',
+        '--skipVersionUpgrade ....... skips upgrading appVersion and appVersionCode',
         '--ignore [fields-list]................. the fields which you would like to keep the same.',
         'You can enter each key from your Web Manifest.',
       ].join('\n')],

--- a/packages/cli/src/lib/cmds/merge.ts
+++ b/packages/cli/src/lib/cmds/merge.ts
@@ -32,11 +32,16 @@ export async function merge(args: ParsedArgs): Promise<boolean> {
   const webManifest = await util.getWebManifest(webManifestUrl);
   const newTwaManifest =
       await TwaManifest.merge(fieldsToIgnore, webManifestUrl, webManifest, twaManifest);
+
   // Update the app (args are not relevant in this case, because update's default values
   // are valid for it. We just send something as an input).
-  const newVersionInfo = await updateVersions(newTwaManifest, twaManifest.appVersionName);
-  newTwaManifest.appVersionName = newVersionInfo.appVersionName;
-  newTwaManifest.appVersionCode = newVersionInfo.appVersionCode;
+  if (!args.skipVersionUpgrade) {
+    const newVersionInfo =
+      await updateVersions(newTwaManifest, args.appVersionName || twaManifest.appVersionName);
+    newTwaManifest.appVersionName = newVersionInfo.appVersionName;
+    newTwaManifest.appVersionCode = newVersionInfo.appVersionCode;
+  }
+
   await newTwaManifest.saveToFile(manifestPath);
   return true;
 }


### PR DESCRIPTION
In our current flow for updating the TWA, we ran into the issue that we couldn't run `bubblewrap merge && bubblewrap update` in a way that would allow us to increment the version (only once) and change the version name. `bubblewrap update` allows us to do both things, but `bubblewrap merge` doesn't allow us to name the version or to skip upgrading. So, I'm suggesting replicating the logic for `update` in `merge`.