### PR TITLE
Fixes artifacts when upscaling images for the Splash Screen

### DIFF
--- a/packages/core/src/lib/ImageHelper.ts
+++ b/packages/core/src/lib/ImageHelper.ts
@@ -36,18 +36,33 @@ interface Icon {
 }
 
 export class ImageHelper {
-  private async saveIcon(icon: Icon, size: number, fileName: string): Promise<void> {
+  private async saveIcon(
+      icon: Icon, size: number, fileName: string, backgroundColor?: Color): Promise<void> {
     const image = await Jimp.read(icon.data);
 
-    // Jimp creates artifacts when upscaling images that have an alpha channel. To avoid those
-    // issues we use the nearest neighbor algorithm only when upscaling.
+    // Jimp creates artifacts when upscaling images that have an alpha channel. This happens
+    // because even when a pixel is fully transparent the RGB part of the color still gets blended
+    // with other pixels. To avoid this, we apply the RGB part of `backgroundColor` to transparent
+    // pixels so they are blended with that color instead and match a background.
     // See https://github.com/GoogleChromeLabs/bubblewrap/issues/488#issuecomment-806560923.
-    if (image.hasAlpha() && (size > image.getWidth() || size > image.getHeight())) {
-      console.log('USINT NEAREST NEIGHBOUR');
-      image.resize(size, size, Jimp.RESIZE_NEAREST_NEIGHBOR);
-    } else {
-      image.resize(size, size);
+    if (backgroundColor && image.hasAlpha()) {
+      // The replacement colour is the same as the background colour, but fully transparent.
+      const replacementColor = (backgroundColor.rgbNumber() << 8) & 0xFFFFFF00;
+
+      // Iterate over the pixels, check for fully transparent ones and replace with
+      // replacementColor.
+      for (let y = 0; y < image.getHeight(); y++) {
+        for (let x = 0; x < image.getWidth(); x++) {
+          const color = image.getPixelColour(x, y);
+
+          // Apply replacement color if the pixel is fully transparent.
+          if ((color & 0xFF) === 0) {
+            image.setPixelColour(replacementColor, x, y);
+          }
+        }
+      }
     }
+    image.resize(size, size);
     await image.writeAsync(fileName);
   }
 
@@ -58,11 +73,11 @@ export class ImageHelper {
    * @param {string} targetDir Path to the directory the image will be saved in.
    * @param {Object} iconDef Icon definitions specifying the size the icon should be exported as.
    */
-  async generateIcon(
-      icon: Icon, targetDir: string, iconDef: IconDefinition): Promise<void> {
+  async generateIcon(icon: Icon, targetDir: string, iconDef: IconDefinition,
+      backgroundColor?: Color): Promise<void> {
     const destFile = path.join(targetDir, iconDef.dest);
     await fsMkDir(path.dirname(destFile), {recursive: true});
-    return await this.saveIcon(icon, iconDef.size, destFile);
+    return await this.saveIcon(icon, iconDef.size, destFile, backgroundColor);
   }
 
   /**

--- a/packages/core/src/lib/ImageHelper.ts
+++ b/packages/core/src/lib/ImageHelper.ts
@@ -38,7 +38,16 @@ interface Icon {
 export class ImageHelper {
   private async saveIcon(icon: Icon, size: number, fileName: string): Promise<void> {
     const image = await Jimp.read(icon.data);
-    image.resize(size, size);
+
+    // Jimp creates artifacts when upscaling images that have an alpha channel. To avoid those
+    // issues we use the nearest neighbor algorithm only when upscaling.
+    // See https://github.com/GoogleChromeLabs/bubblewrap/issues/488#issuecomment-806560923.
+    if (image.hasAlpha() && (size > image.getWidth() || size > image.getHeight())) {
+      console.log('USINT NEAREST NEIGHBOUR');
+      image.resize(size, size, Jimp.RESIZE_NEAREST_NEIGHBOR);
+    } else {
+      image.resize(size, size);
+    }
     await image.writeAsync(fileName);
   }
 

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -16,6 +16,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import * as Color from 'color';
 import fetch from 'node-fetch';
 import {template} from 'lodash';
 import {promisify} from 'util';
@@ -69,17 +70,20 @@ const DELETE_FILE_LIST = [
   'app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml',
 ];
 
+const SPLASH_IMAGES: IconDefinition[] = [
+  {dest: 'app/src/main/res/drawable-hdpi/splash.png', size: 450},
+  {dest: 'app/src/main/res/drawable-mdpi/splash.png', size: 300},
+  {dest: 'app/src/main/res/drawable-xhdpi/splash.png', size: 600},
+  {dest: 'app/src/main/res/drawable-xxhdpi/splash.png', size: 900},
+  {dest: 'app/src/main/res/drawable-xxxhdpi/splash.png', size: 1200},
+];
+
 const IMAGES: IconDefinition[] = [
   {dest: 'app/src/main/res/mipmap-hdpi/ic_launcher.png', size: 72},
   {dest: 'app/src/main/res/mipmap-mdpi/ic_launcher.png', size: 48},
   {dest: 'app/src/main/res/mipmap-xhdpi/ic_launcher.png', size: 96},
   {dest: 'app/src/main/res/mipmap-xxhdpi/ic_launcher.png', size: 144},
   {dest: 'app/src/main/res/mipmap-xxxhdpi/ic_launcher.png', size: 192},
-  {dest: 'app/src/main/res/drawable-hdpi/splash.png', size: 450},
-  {dest: 'app/src/main/res/drawable-mdpi/splash.png', size: 300},
-  {dest: 'app/src/main/res/drawable-xhdpi/splash.png', size: 600},
-  {dest: 'app/src/main/res/drawable-xxhdpi/splash.png', size: 900},
-  {dest: 'app/src/main/res/drawable-xxxhdpi/splash.png', size: 1200},
   {dest: 'store_icon.png', size: 512},
 ];
 
@@ -247,11 +251,11 @@ export class TwaGenerator {
     }));
   }
 
-  private async generateIcons(
-      iconUrl: string, targetDir: string, iconList: IconDefinition[]): Promise<void> {
+  private async generateIcons(iconUrl: string, targetDir: string, iconList: IconDefinition[],
+      backgroundColor?: Color): Promise<void> {
     const icon = await this.imageHelper.fetchIcon(iconUrl);
     await Promise.all(iconList.map((iconDef) => {
-      return this.imageHelper.generateIcon(icon, targetDir, iconDef);
+      return this.imageHelper.generateIcon(icon, targetDir, iconDef, backgroundColor);
     }));
   }
 
@@ -412,6 +416,8 @@ export class TwaGenerator {
     // Generate images
     if (twaManifest.iconUrl) {
       await this.generateIcons(twaManifest.iconUrl, targetDirectory, IMAGES);
+      await this.generateIcons(
+          twaManifest.iconUrl, targetDirectory, SPLASH_IMAGES, twaManifest.backgroundColor);
     }
     progress.update();
 

--- a/packages/core/src/lib/TwaGenerator.ts
+++ b/packages/core/src/lib/TwaGenerator.ts
@@ -71,16 +71,16 @@ const DELETE_FILE_LIST = [
 ];
 
 const SPLASH_IMAGES: IconDefinition[] = [
-  {dest: 'app/src/main/res/drawable-hdpi/splash.png', size: 450},
   {dest: 'app/src/main/res/drawable-mdpi/splash.png', size: 300},
+  {dest: 'app/src/main/res/drawable-hdpi/splash.png', size: 450},
   {dest: 'app/src/main/res/drawable-xhdpi/splash.png', size: 600},
   {dest: 'app/src/main/res/drawable-xxhdpi/splash.png', size: 900},
   {dest: 'app/src/main/res/drawable-xxxhdpi/splash.png', size: 1200},
 ];
 
 const IMAGES: IconDefinition[] = [
-  {dest: 'app/src/main/res/mipmap-hdpi/ic_launcher.png', size: 72},
   {dest: 'app/src/main/res/mipmap-mdpi/ic_launcher.png', size: 48},
+  {dest: 'app/src/main/res/mipmap-hdpi/ic_launcher.png', size: 72},
   {dest: 'app/src/main/res/mipmap-xhdpi/ic_launcher.png', size: 96},
   {dest: 'app/src/main/res/mipmap-xxhdpi/ic_launcher.png', size: 144},
   {dest: 'app/src/main/res/mipmap-xxxhdpi/ic_launcher.png', size: 192},
@@ -88,8 +88,8 @@ const IMAGES: IconDefinition[] = [
 ];
 
 const ADAPTIVE_IMAGES: IconDefinition[] = [
-  {dest: 'app/src/main/res/mipmap-hdpi/ic_maskable.png', size: 123},
   {dest: 'app/src/main/res/mipmap-mdpi/ic_maskable.png', size: 82},
+  {dest: 'app/src/main/res/mipmap-hdpi/ic_maskable.png', size: 123},
   {dest: 'app/src/main/res/mipmap-xhdpi/ic_maskable.png', size: 164},
   {dest: 'app/src/main/res/mipmap-xxhdpi/ic_maskable.png', size: 246},
   {dest: 'app/src/main/res/mipmap-xxxhdpi/ic_maskable.png', size: 328},


### PR DESCRIPTION
[UPDATED]

Upscaling images using Jimp can generate artifacts when transparent pixels are blended with opaque pixels.  See #488 for more details on the issue.

This happens because, even though the alpha channel sets the pixel to fully transparent, those pixels still have an RGB part to their color. 

As example, if a transparent pixel is `#000000FF` is a transparent pixel that has a black RGB part,  merging with an opaque white like`#FFFFFF00` will result in a semi-transparent grey (eg: `#7F7F7F7F`). However, what we want in this case is for the color to be a semi-transparent white (`#FFFFFF7F`).

Since we know the background color the splash icon is going to be rendered against we can assign the RGB part of the background color to all fully transparent pixels, so that the opaque pixels will be blended against the background color, avoiding artifacts on the border of transparent regions of the image.

This is what an image upscaled with this workaround looks like:
![splash](https://user-images.githubusercontent.com/1733592/114029591-93016280-9871-11eb-8bec-6f85f2e3c34a.png)


