### PR TITLE
Doesn't set splash screen orientation on Oreo and below

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -310,12 +310,12 @@ export function escapeJsonString(stringToReplace: string): string {
 //
 export function toAndroidScreenOrientation(orientation: Orientation): string {
   switch (orientation) {
-    case 'portrait': return 'userPortrait';
-    case 'portrait-primary': return 'portrait';
-    case 'portrait-secondary': return 'reversePortrait';
-    case 'landscape': return 'landscape';
-    case 'landspace-primary': return 'userLandscape';
-    case 'landscape-secondary': return 'reverseLandscape';
-    default: return 'unspecified';
+    case 'portrait': return 'ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT';
+    case 'portrait-primary': return 'ActivityInfo.SCREEN_ORIENTATION_PORTRAIT';
+    case 'portrait-secondary': return 'ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT';
+    case 'landscape': return 'ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE';
+    case 'landspace-primary': return 'ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE';
+    case 'landscape-secondary': return 'ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE';
+    default: return 'ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED';
   }
 }

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -295,6 +295,9 @@ export function escapeJsonString(stringToReplace: string): string {
 // This is the value of the screenOrientation for the LauncherActivity which determines the
 // orientation of the splash screen.
 // This methods maps the Web Manifest orientation to the android screenOrientation:
+//  - "default"             => "unspecified"
+//  - "any"                 => "unspecified"
+//  - "natural "            => "unspecified"
 //  - "portrait"            => "userPortrait"
 //  - "portrait-primary"    => "portrait"
 //  - "portrait-secondary"  => "reversePortrait"

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -257,4 +257,32 @@ describe('util', () => {
       mockFs.restore();
     });
   });
+
+  describe('#toAndroidScreenOrientation', () => {
+    it('Returns the correct orientation', () => {
+      expect(util.toAndroidScreenOrientation('portrait'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT');
+      expect(util.toAndroidScreenOrientation('portrait-primary'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_PORTRAIT');
+      expect(util.toAndroidScreenOrientation('portrait-secondary'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT');
+      expect(util.toAndroidScreenOrientation('landscape'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE');
+      expect(util.toAndroidScreenOrientation('landspace-primary'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE');
+      expect(util.toAndroidScreenOrientation('landscape-secondary'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE');
+      expect(util.toAndroidScreenOrientation('default'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED');
+      expect(util.toAndroidScreenOrientation('any'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED');
+      expect(util.toAndroidScreenOrientation('natural'))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED');
+    });
+
+    it('Returns unspecified for invalid values', () => {
+      expect(util.toAndroidScreenOrientation(''))
+          .toEqual('ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED');
+    });
+  });
 });

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -64,7 +64,6 @@
         <% } %>
 
         <activity android:name="LauncherActivity"
-            android:screenOrientation="<%= toAndroidScreenOrientation(orientation) %>"
             android:alwaysRetainTaskState="true"
             android:label="@string/launcherName">
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"

--- a/packages/core/template_project/app/src/main/java/LauncherActivity.java
+++ b/packages/core/template_project/app/src/main/java/LauncherActivity.java
@@ -15,7 +15,10 @@
  */
 package <%= packageId %>;
 
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
 
 <% for(const imp of launcherActivity.imports) { %>
     import <%= imp %>;
@@ -30,6 +33,20 @@ public class LauncherActivity
     <% for(const method of launcherActivity.methods) { %>
         <%= method %>
     <% } %>
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Setting an orientation crashes the app due to the transparent background on Android 8.0
+        // Oreo and below. We only set the orientation on Oreo and above. This only affects the
+        // splash screen and Chrome will still respect the orientation.
+        // See https://github.com/GoogleChromeLabs/bubblewrap/issues/496 for details.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            setRequestedOrientation(<%= toAndroidScreenOrientation(orientation) %>);
+        } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
+    }
 
     @Override
     protected Uri getLaunchingUrl() {


### PR DESCRIPTION
- Devices running Android 8.0 and below crash when a screen
  orientation is set and the theme is transparent.
- We ensure only setting the screen orientation on Oreo and below.
- This doesn't affect how Chrome handles orientation, only the
  splash screen.

Fixes #496 