### PR TITLE
Add prompt for location delegation to bubblewrap init

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -147,6 +147,17 @@ async function confirmTwaConfig(twaManifest: TwaManifest, prompt: Prompt): Promi
     };
   }
 
+  const locationDelegationEnabled =
+      await prompt.promptConfirm(messages.promptLocationDelegation, false);
+  if (locationDelegationEnabled) {
+    twaManifest.features = {
+      ...twaManifest.features,
+      locationDelegation: {
+        enabled: true,
+      },
+    };
+  }
+
   // Step 5/5 Signing Key Information.
   prompt.printMessage(messages.messageSigningKeyInformation);
   prompt.printMessage(messages.messageSigningKeyInformationDesc);

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -92,6 +92,7 @@ type Messages = {
   promptMonochromeIconUrl: string;
   promptShortcuts: string;
   promptPlayBilling: string;
+  promptLocationDelegation: string;
   promptPackageId: string;
   promptKeyPath: string;
   promptKeyAlias: string;
@@ -325,6 +326,7 @@ the PWA:
   promptMonochromeIconUrl: 'Monochrome icon URL:',
   promptShortcuts: 'Include app shortcuts?',
   promptPlayBilling: 'Include support for Play Billing (this relies on alpha dependencies)?',
+  promptLocationDelegation: 'Request geolocation permission?',
   promptPackageId: 'Application ID:',
   promptKeyPath: 'Key store location:',
   promptKeyAlias: 'Key name:',


### PR DESCRIPTION
If a TWA needs geolocation, enable location delegation