### PR TITLE
Auto apply twa manifest changes

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -65,8 +65,6 @@ class Build {
     const prevChecksum = (await fs.promises.readFile(checksumFile)).toString();
     const manifestContents = await fs.promises.readFile(manifestFile);
     const currChecksum = computeChecksum(manifestContents);
-    this.prompt.printMessage('New checksum found to be: ' + currChecksum);
-    this.prompt.printMessage('Old checksum is: ' + prevChecksum);
     return currChecksum != prevChecksum;
   }
 
@@ -162,7 +160,7 @@ class Build {
     if (hasManifestChanged) {
       const applyChanges = await this.prompt.promptConfirm(messages.promptUpdateProject, true);
       if (applyChanges) {
-        const updated = await updateProject(false, '', this.prompt,
+        const updated = await updateProject(false, null, this.prompt,
             this.args.directory, manifestFile);
         if (!updated) {
           return false;

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -24,7 +24,7 @@ import {validateHost, validateColor, createValidateString, validateDisplayMode, 
 import {APP_NAME} from '../constants';
 import {Prompt, InquirerPrompt} from '../Prompt';
 import {enUS as messages} from '../strings';
-import {generateTwaProject} from './shared';
+import {generateTwaProject, generateManifestChecksumFile} from './shared';
 
 export interface InitArgs {
   manifest?: string;
@@ -254,6 +254,7 @@ export async function init(
   const twaGenerator = new TwaGenerator();
   await twaManifest.saveToFile(join(targetDirectory, '/twa-manifest.json'));
   await generateTwaProject(prompt, twaGenerator, targetDirectory, twaManifest);
+  await generateManifestChecksumFile(join(targetDirectory, '/twa-manifest.json'), prompt);
   await createSigningKey(twaManifest, config, prompt);
   prompt.printMessage(messages.messageProjectGeneratedSuccess);
   return true;

--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -254,7 +254,7 @@ export async function init(
   const twaGenerator = new TwaGenerator();
   await twaManifest.saveToFile(join(targetDirectory, '/twa-manifest.json'));
   await generateTwaProject(prompt, twaGenerator, targetDirectory, twaManifest);
-  await generateManifestChecksumFile(join(targetDirectory, '/twa-manifest.json'), prompt);
+  await generateManifestChecksumFile(join(targetDirectory, '/twa-manifest.json'), targetDirectory);
   await createSigningKey(twaManifest, config, prompt);
   prompt.printMessage(messages.messageProjectGeneratedSuccess);
   return true;

--- a/packages/cli/src/lib/cmds/shared.ts
+++ b/packages/cli/src/lib/cmds/shared.ts
@@ -14,6 +14,9 @@
  *  limitations under the License.
  */
 
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import {InquirerPrompt, Prompt} from '../Prompt';
 import {enUS as messages} from '../strings';
 import {Presets, Bar} from 'cli-progress';
@@ -83,4 +86,17 @@ export async function updateVersions(
     appVersionCode: appVersionCode,
     appVersionName: appVersionName,
   };
+}
+
+export async function generateManifestChecksumFile(manifestFile: string,
+    prompt: Prompt): Promise<void> {
+  fs.readFile(manifestFile, async function(err, data) {
+    if (err) {
+      prompt.printMessage(err.toString());
+      return;
+    }
+    const csFile = path.join(process.cwd(), 'manifest-checksum.txt');
+    const sum = crypto.createHash('sha1').update(data).digest('hex');
+    await fs.promises.writeFile(csFile, sum);
+  });
 }

--- a/packages/cli/src/lib/cmds/shared.ts
+++ b/packages/cli/src/lib/cmds/shared.ts
@@ -48,11 +48,11 @@ export async function generateTwaProject(prompt: Prompt, twaGenerator: TwaGenera
 /**
  * Compute the new app version.
  * @param {TwaManifest} oldTwaManifest current Twa Manifest.
- * @param {string} currentAppVersionName the current app's version name (optional) .
+ * @param {string | null} currentAppVersionName the current app's version name (or null) .
  * @param {Prompt} prompt prompt instance to get information from the user if needed.
  */
 export async function updateVersions(
-    twaManifest: TwaManifest, currentAppVersionName: string,
+    twaManifest: TwaManifest, currentAppVersionName: string | null,
     prompt: Prompt = new InquirerPrompt()): Promise<{
     appVersionName: string;
     appVersionCode: number;
@@ -101,9 +101,18 @@ export async function generateManifestChecksumFile(manifestFile: string,
   await fs.promises.writeFile(checksumFile, sum);
 }
 
+/**
+ * Update the TWA project.
+ * @param skipVersionUpgrade {boolean} Skips upgrading appVersionCode and appVersionName if set to true.
+ * @param appVersionName {string | null} Value to be used for appVersionName when upgrading
+ * versions. Ignored if `args.skipVersionUpgrade` is set to true. If null, a default is used or user will be prompted for one.
+ * @param prompt {Prompt} Prompt instance to get information from the user if necessary.
+ * @param directory {string} TWA project directory.
+ * @param manifest {string} Path to twa-manifest.json file.
+ */
 export async function updateProject(
     skipVersionUpgrade: boolean,
-    appVersionName: string,
+    appVersionName: string | null,
     prompt: Prompt = new InquirerPrompt(),
     directory: string,
     manifest: string): Promise<boolean> {

--- a/packages/cli/src/lib/cmds/update.ts
+++ b/packages/cli/src/lib/cmds/update.ts
@@ -20,7 +20,7 @@ import {TwaGenerator, TwaManifest} from '@bubblewrap/core';
 import {ParsedArgs} from 'minimist';
 import {APP_NAME} from '../constants';
 import {enUS as messages} from '../strings';
-import {updateVersions, generateTwaProject} from './shared';
+import {updateVersions, generateTwaProject, generateManifestChecksumFile} from './shared';
 
 /**
  * Updates an existing TWA Project using the `twa-manifest.json`.
@@ -64,6 +64,7 @@ export async function update(
   if (!args.skipVersionUpgrade) {
     twaManifest.saveToFile(manifestFile);
   }
+  await generateManifestChecksumFile(manifestFile, prompt);
   prompt.printMessage(messages.messageProjectUpdatedSuccess);
   return true;
 }

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -45,7 +45,6 @@ type Messages = {
   messageApkSuccess: (filename: string) => string;
   messageAppBundleSuccess: (filename: string) => string;
   messageBuildingApp: string;
-  messageContinueBuildingApp: string;
   messageDigitalAssetLinksSuccess: (filename: string) => string;
   messageEnterPasswords: (keypath: string, keyalias: string) => string;
   messageGeneratedAssetLinksFile: (outputfile: string) => string;
@@ -58,6 +57,8 @@ type Messages = {
   messageOptionalFeaturesDesc: string;
   messageProjectGeneratedSuccess: string;
   messageProjectUpdatedSuccess: string;
+  messageProjectBuildReminder: string;
+  messageProjectNotUpdated: string;
   messageRemovedFingerprint: (fingerpring: Fingerprint) => string;
   messageSavingTwaManifestTo: (path: string) => string;
   messageSha256FingerprintNotFound: string;
@@ -204,7 +205,6 @@ into a device:
     return `\t- Generated Android App Bundle at ${cyan(filename)}`;
   },
   messageBuildingApp: '\nBuilding the Android App...',
-  messageContinueBuildingApp: 'Continuing with ' + cyan('bubblewrap build'),
   messageDigitalAssetLinksSuccess: (filename: string): string => {
     return `\t- Generated Digital Asset Links file at ${cyan(filename)}
 \nRead more about setting up Digital Asset Links at:
@@ -259,8 +259,10 @@ a blank white page to users.
 \t  ${italic('theme_color')}. They will be used for notification icons.\n`,
   messageProjectGeneratedSuccess: '\nProject generated successfully. Build it by running ' +
       cyan('bubblewrap build'),
-  messageProjectUpdatedSuccess: '\nProject updated successfully. Build it by running ' +
-      cyan('bubblewrap build'),
+  messageProjectUpdatedSuccess: '\nProject updated successfully.',
+  messageProjectBuildReminder: 'Build it by running ' + cyan('bubblewrap build'),
+  messageProjectNotUpdated: '\nProject build will continue without newest ' +
+      cyan('twa-manifest.json') + ' changes.',
   messageRemovedFingerprint: (fingerprint: Fingerprint): string => {
     return `Removed fingerprint with value ${fingerprint.value}.`;
   },

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -45,6 +45,7 @@ type Messages = {
   messageApkSuccess: (filename: string) => string;
   messageAppBundleSuccess: (filename: string) => string;
   messageBuildingApp: string;
+  messageContinueBuildingApp: string;
   messageDigitalAssetLinksSuccess: (filename: string) => string;
   messageEnterPasswords: (keypath: string, keyalias: string) => string;
   messageGeneratedAssetLinksFile: (outputfile: string) => string;
@@ -108,6 +109,7 @@ type Messages = {
   promptKeyPassword: string;
   promptNewAppVersionName: string;
   promptVersionCode: string;
+  promptUpdateProject: string;
   warnPwaFailedQuality: string;
   updateConfigUsage: string;
   jdkPathIsNotCorrect: string;
@@ -202,6 +204,7 @@ into a device:
     return `\t- Generated Android App Bundle at ${cyan(filename)}`;
   },
   messageBuildingApp: '\nBuilding the Android App...',
+  messageContinueBuildingApp: 'Continuing with ' + cyan('bubblewrap build'),
   messageDigitalAssetLinksSuccess: (filename: string): string => {
     return `\t- Generated Digital Asset Links file at ${cyan(filename)}
 \nRead more about setting up Digital Asset Links at:
@@ -348,6 +351,8 @@ the PWA:
   promptKeyPassword: 'Password for the Key:',
   promptNewAppVersionName: 'versionName for the new App version:',
   promptVersionCode: 'Starting version code for the new app version:',
+  promptUpdateProject: 'There are changes in twa-manifest.json. ' +
+      'Would you like to apply them to the project before building?',
   warnPwaFailedQuality: red('PWA Quality Criteria check failed.'),
   updateConfigUsage: 'Usage: [--jdkPath <path-to-jdk>] [--androidSdkPath <path-to-android-sdk>]' +
       '(You can insert one or both of them)',


### PR DESCRIPTION
Using checksum to track changes to `twa-manifest.json`, if a user tries to build a outdated version of the project, they will be prompted if they would like to apply the newest changes before building.