### PR TITLE
Uses android:resource for notification icon

### DIFF
--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -172,7 +172,7 @@
             <% if (monochromeIconUrl) { %>
                 <meta-data
                     android:name="android.support.customtabs.trusted.SMALL_ICON"
-                    android:value="@drawable/ic_notification_icon" />
+                    android:resource="@drawable/ic_notification_icon" />
             <% } %>
 
             <intent-filter>


### PR DESCRIPTION
Using android:value causes the resource to be interpreted as a
String and causes the Service to fail to retrieve the proper icon.