### PR TITLE
Checks for existing JDK and AndroidSDK installs.

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -35,7 +35,6 @@ const DEFAULT_JDK_FOLDER = join(DEFAULT_CONFIG_FOLDER, 'jdk');
 const DEFAULT_SDK_FOLDER = join(DEFAULT_CONFIG_FOLDER, 'android_sdk');
 
 async function configAndroidSdk(prompt: Prompt = new InquirerPrompt()): Promise<string> {
-
   const sdkInstallRequest = await prompt.promptConfirm(messages.promptInstallSdk, true);
 
   let sdkPath;
@@ -107,7 +106,7 @@ export async function loadOrCreateConfig(
   }
   let config = await Config.loadConfig(configPath);
   if (!config) {
-    config = new Config("","");
+    config = new Config('', '');
     config.saveConfig(configPath);
   }
 


### PR DESCRIPTION
This change checks for existing Android SDK and JDK installs so it does
not overwrite existing installations on disk. The check is done by
seeing if the existing bubblewrap config has a value set for JDK and
AndroidSDK fields. This change aims to resolve issue #547 where the user
exits the installation process halfway through and then resumes again
and is prompted to reinstall the JDK.

Closes #547