### PR TITLE
Fix missing checksum

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -143,7 +143,6 @@ class Build {
   }
 
   /**
-   *
    * Based on the promptResponse to update the project or not, run an update or print the relevant warning message.
    */
   async runUpdate(

--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -156,7 +156,7 @@ class Build {
       return true;
     }
     return await updateProject(false, null, this.prompt,
-      this.args.directory, manifestFile);
+        this.args.directory, manifestFile);
   }
 
   async build(): Promise<boolean> {

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -55,6 +55,8 @@ type Messages = {
   messageLauncherIconAndSplash: string;
   messageLauncherIconAndSplashDesc: string;
   messageLoadingTwaManifestFrom: (path: string) => string;
+  messageNoChecksumFileFound: string;
+  messageNoChecksumNoUpdate: string;
   messageOptionFeatures: string;
   messageOptionalFeaturesDesc: string;
   messagePlayUploadSuccess: string;
@@ -254,6 +256,13 @@ a blank white page to users.
   messageLoadingTwaManifestFrom: (path: string): string => {
     return `Loading TWA Manifest from: ${cyan(path)}`;
   },
+  messageNoChecksumFileFound: `
+No checksum file was found to verify the state of the ${cyan('twa-manifest.json')} file.
+To make sure your project is up-to-date, would you like to regenerate your project?
+If you are sure your project is updated and you have already run ${cyan('bubblewrap update')}
+then you may enter "no"`,
+  messageNoChecksumNoUpdate: `
+Project build will continue without regenerating project even though no checksum file was found.`,
   messageOptionFeatures: underline(`\nOptional Features ${green('(4/5)')}`),
   messageOptionalFeaturesDesc: `
 \t- ${bold('Include app shortcuts:')} This question is only prompted if a


### PR DESCRIPTION
This is supposed to fix what happens when a checksum file doesn't currently exist yet to verify the state of twa-manifest.json. This will happen for users updating to the most recent version of Bubblewrap and run `bubblewrap build` without running `bubblewrap update` which will generate the checksum. When `bubblewrap build` doesn't find the checksum file, it will prompt the user whether they would like to generate their project again (which will create checksum) or build without regenerating the project.