### PR TITLE
Add a warning for the play family policy.

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -34,6 +34,9 @@ export interface InitArgs {
 }
 
 async function confirmTwaConfig(twaManifest: TwaManifest, prompt: Prompt): Promise<TwaManifest> {
+  // Warn about the Google Play Family Policy
+  prompt.printMessage(messages.warnFamilyPolicy);
+
   // Step 1/5 - Collect information on the Web App.
   prompt.printMessage(messages.messageWebAppDetails);
   prompt.printMessage(messages.messageWebAppDetailsDesc);

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -369,7 +369,7 @@ the PWA:
   promptVersionCode: 'Starting version code for the new app version:',
   promptUpdateProject: 'There are changes in twa-manifest.json. ' +
       'Would you like to apply them to the project before building?',
-  warnFamilyPolicy: bold(red('WARNING: ')) + 'Trusted Web Activities are currently incompatible' +
+  warnFamilyPolicy: bold(yellow('WARNING: ')) + 'Trusted Web Activities are currently incompatible' +
       ' with applications\ntargeting children under the age of 13.' +
       ' Check out the Play for' +
       ' Families\npolicies to learn more.\n' +

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -117,6 +117,7 @@ type Messages = {
   promptNewAppVersionName: string;
   promptVersionCode: string;
   promptUpdateProject: string;
+  warnFamilyPolicy: string;
   warnPwaFailedQuality: string;
   updateConfigUsage: string;
   jdkPathIsNotCorrect: string;
@@ -368,6 +369,11 @@ the PWA:
   promptVersionCode: 'Starting version code for the new app version:',
   promptUpdateProject: 'There are changes in twa-manifest.json. ' +
       'Would you like to apply them to the project before building?',
+  warnFamilyPolicy: bold(red('WARNING: ')) + 'Trusted Web Activities are currently incompatible' +
+      ' with applications\ntargeting children under the age of 13.' +
+      ' Check out the Play for' +
+      ' Families\npolicies to learn more.\n' +
+      cyan('https://play.google.com/console/about/families/'),
   warnPwaFailedQuality: red('PWA Quality Criteria check failed.'),
   updateConfigUsage: 'Usage: [--jdkPath <path-to-jdk>] [--androidSdkPath <path-to-android-sdk>]' +
       '(You can insert one or both of them)',

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -369,7 +369,8 @@ the PWA:
   promptVersionCode: 'Starting version code for the new app version:',
   promptUpdateProject: 'There are changes in twa-manifest.json. ' +
       'Would you like to apply them to the project before building?',
-  warnFamilyPolicy: bold(yellow('WARNING: ')) + 'Trusted Web Activities are currently incompatible' +
+  warnFamilyPolicy:
+      bold(yellow('WARNING: ')) + 'Trusted Web Activities are currently incompatible' +
       ' with applications\ntargeting children under the age of 13.' +
       ' Check out the Play for' +
       ' Families\npolicies to learn more.\n' +


### PR DESCRIPTION
This adds a warning for the Google Play Family Policy to let developers
know about being in compliance and also provides a link for them to
visit to find out more information.
Fixes #545