### PR TITLE
Disable the play command.

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -29,7 +29,7 @@ import {updateConfig} from './cmds/updateConfig';
 import {doctor} from './cmds/doctor';
 import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
-import {play, PlayArgs} from './cmds/play';
+// import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
 
 export class Cli {

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -88,8 +88,8 @@ export class Cli {
         return await merge(parsedArgs);
       case 'fingerprint':
         return await fingerprint(parsedArgs);
-      case 'play':
-        return await play(config, parsedArgs as unknown as PlayArgs);
+      // case 'play':
+      //   return await play(config, parsedArgs as unknown as PlayArgs);
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);


### PR DESCRIPTION
In discussions that we have had, we decided it was best to disable the
play command before we cut another release of bubblewrap. Once we are
more confident in our ability with the command, we will turn it on for
expiremental use.