### PR TITLE
Await the saveConfig

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -113,13 +113,13 @@ export async function loadOrCreateConfig(
   if (!config.jdkPath) {
     const jdkPath = await configureJdk(prompt);
     config.jdkPath = jdkPath;
-    config.saveConfig(configPath);
+    await config.saveConfig(configPath);
   }
 
   if (!config.androidSdkPath) {
     const androidSdkPath = await configAndroidSdk(prompt);
     config.androidSdkPath = androidSdkPath;
-    config.saveConfig(configPath);
+    await config.saveConfig(configPath);
   }
 
   return config;


### PR DESCRIPTION
This fixes a bug where the AndroidSDK could be downloaded twice because the config was not being saved if an invalid manifest was supplied. Adding the await will wait for the saveConfig method to finish before continuing execution.