### PR TITLE
Refactor from GradlePlayPlugin to API Directly

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -29,7 +29,7 @@ import {updateConfig} from './cmds/updateConfig';
 import {doctor} from './cmds/doctor';
 import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
-import {play, PlayArgs} from './cmds/play';
+// import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
 
 export class Cli {
@@ -88,8 +88,8 @@ export class Cli {
         return await merge(parsedArgs);
       case 'fingerprint':
         return await fingerprint(parsedArgs);
-      case 'play':
-        return await play(parsedArgs as unknown as PlayArgs);
+      // case 'play':
+      //   return await play(parsedArgs as unknown as PlayArgs);
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -29,7 +29,7 @@ import {updateConfig} from './cmds/updateConfig';
 import {doctor} from './cmds/doctor';
 import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
-// import {play, PlayArgs} from './cmds/play';
+import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
 
 export class Cli {
@@ -88,8 +88,8 @@ export class Cli {
         return await merge(parsedArgs);
       case 'fingerprint':
         return await fingerprint(parsedArgs);
-      // case 'play':
-      //   return await play(config, parsedArgs as unknown as PlayArgs);
+      case 'play':
+        return await play(parsedArgs as unknown as PlayArgs);
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -80,6 +80,10 @@ class Play {
     return await this.internalPublish(defaultPath, userSelectedTrack, twaManifest);
   }
 
+  /**
+  * Calls the internalPublish commands.
+  * @return {boolean} Whether the publish command completes successfully or not.
+  */
   private async internalPublish(
       bundleLocation: string,
       userSelectedTrack: string,
@@ -111,6 +115,12 @@ class Play {
     return true;
   }
 
+  /**
+  * Updates the gradle file based on the updates to the twa-manifest.json file and warns the user
+  *   that they need to call build again.
+  * @param {string} manifestFile - The path to the the TwaManifest JSON file.
+  * @param {string} appVersionName - Optional: Changes the string representation of the version.
+  */
   private async updateProjectAndWarn(manifestFile: string, appVersionName?: string): Promise<void> {
     await updateProject(
         true,

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -43,14 +43,6 @@ class Play {
   ) {}
 
   /**
-  * Bootstraps the Play listing via the Gradle-Play-Plugin.
-  * @return {void}
-  */
-  async bootstrapPlay(): Promise<void> {
-    this.prompt.printMessage('This does nothing now');
-  }
-
-  /**
   * @summary Can validate the largest version number vs twa-manifest.json and update
   * to give x+1 version number.
   * @return {number} The largest version number found in the play console.
@@ -153,11 +145,6 @@ class Play {
     }
     // Setup Google Play since we can confirm that the serviceAccountJsonFile is valid.
     this.googlePlay = new GooglePlay(twaManifest.serviceAccountJsonFile!);
-
-    // bubblewrap play --init
-    if (this.args.init) {
-      await this.bootstrapPlay();
-    }
 
     // bubblewrap play --versionCheck
     if (this.args.versionCheck) {

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -160,7 +160,7 @@ class Play {
   * @param {string | undefined} path - The path the the JSON file.
   * @return {boolean} Whether or not the JSON file exists.
   */
- function validServiceAccountJsonFile(path: string | undefined): boolean {
+function validServiceAccountJsonFile(path: string | undefined): boolean {
   if (path == undefined) {
     // Log an error
     return false;

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -114,7 +114,7 @@ export class GooglePlay {
       packageName: packageName,
       editId: editId,
       requestBody: {
-        releases: [{versionCodes: versionCodes}],
+        releases: [{versionCodes: versionCodes, status: 'completed'}],
         track: track,
       },
     };

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -18,9 +18,6 @@ import groovy.xml.MarkupBuilder
 
 plugins {
     id 'com.android.application'
-    <% if (serviceAccountJsonFile) { %>
-    id("com.github.triplet.play") version "3.4.0"
-    <% } %>
 }
 
 def twaManifest = [
@@ -153,12 +150,6 @@ android {
         checkReleaseBuilds false
     }
 }
-
-<% if (serviceAccountJsonFile) { %>
-play {
-    serviceAccountCredentials.set(file("<%= serviceAccountJsonFile %>"))
-}
-<% } %>
 
 task generateShorcutsFile {
     assert twaManifest.shortcuts.size() < 5, "You can have at most 4 shortcuts."


### PR DESCRIPTION
This is a refactor of the current GooglePlay integration so it calls the Play API directly rather than the gradle play plugin. This ensures that we are not excessively rebuilding the project or regenerating the gradle file. This update should have no affect on the end users experience of using the `play` command with the exception of removing the no longer needed `init` command.