### PR TITLE
Add serviceAccountJson to constructor

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -59,7 +59,7 @@ class Play {
   * @return {number} The largest version number found in the play console.
   */
   async getLargestVersion(twaManifest: TwaManifest): Promise<number> {
-    //TODO(@nohe427): This will return 0 until refactor finished.
+    // TODO(@nohe427): This will return 0 until refactor finished.
     const versionNumber = await this.googlePlay.getLargestVersionCode(twaManifest.packageId);
     return versionNumber;
   }

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -59,8 +59,8 @@ class Play {
   * @return {number} The largest version number found in the play console.
   */
   async getLargestVersion(twaManifest: TwaManifest): Promise<number> {
-    const versionNumber = await this.googlePlay.getLargestVersionCode(
-        twaManifest.packageId, twaManifest.serviceAccountJsonFile!);
+    //TODO(@nohe427): This will return 0 until refactor finished.
+    const versionNumber = await this.googlePlay.getLargestVersionCode(twaManifest.packageId);
     return versionNumber;
   }
 


### PR DESCRIPTION
This adds the serviceAccountJsonFile to the constructor for the
GooglePlay object. Additionally, it removes some redundant checks for
the versionCode check.