### PR TITLE
Add publishing a bundle via API instead of Gradle.

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -78,7 +78,7 @@ class Play {
     }
     // appbundlelocation is an option argument.
     if (this.args.appBundleLocation && fs.existsSync(this.args.appBundleLocation!!)) {
-      await this.googlePlay.publishBundle(userSelectedTrack, this.args.appBundleLocation);
+      await this.googlePlay.publishBundleWithGradle(userSelectedTrack, this.args.appBundleLocation);
       return true;
     }
     // Make tmp directory copy file over signed APK then cleanup.
@@ -88,7 +88,7 @@ class Play {
     const defaultPath = path.join(process.cwd(), signedAppBundleFileName);
 
     fs.copyFileSync(defaultPath, path.join(publishDir, signedAppBundleFileName));
-    await this.googlePlay.publishBundle(userSelectedTrack, publishDir);
+    await this.googlePlay.publishBundleWithGradle(userSelectedTrack, publishDir);
 
     fs.unlinkSync(path.join(publishDir, signedAppBundleFileName));
     fs.rmdirSync(publishDir);

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -85,7 +85,7 @@ export class GooglePlay {
    * @param retainedBundles - all bundles that should be retained on upload. This is useful for
    *   ChromeOS only releases.
    */
-     async publishBundle(
+  async publishBundle(
       track: PlayStoreTrack,
       filepath: string,
       packageName: string,
@@ -141,7 +141,7 @@ export class GooglePlay {
       versionCodes: string[],
       packageName: string,
       editId: string): Promise<void> {
-        // TODO(@nohe427): Remove this check when refactor is finished.
+    // TODO(@nohe427): Remove this check when refactor is finished.
     if (!this._googlePlayApi) {
       return;
     }

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -23,7 +23,7 @@ const TRACK_VALUES = ['alpha', 'beta', 'internal', 'production'];
 export type PlayStoreTrack = typeof TRACK_VALUES[number];
 export const PlayStoreTracks: PlayStoreTrack[] = [...TRACK_VALUES];
 
-const PLAY_API_TIMEOUT = 180000;
+const PLAY_API_TIMEOUT_MS = 180000;
 
 export function asPlayStoreTrack(input?: string): PlayStoreTrack | null {
   if (!input) {
@@ -100,6 +100,7 @@ export class GooglePlay {
     const edit = await this._googlePlayApi.edits.insert({packageName: packageName});
     const editId = edit.data.id;
     if (!editId) {
+      // TODO(@nohe427): Try to recover and understand instances where this might fail.
       throw new Error('Could not create a Google Play edit');
     }
     const result = await this._googlePlayApi.edits.bundles.upload(
@@ -112,7 +113,7 @@ export class GooglePlay {
           },
         },
         {
-          timeout: PLAY_API_TIMEOUT,
+          timeout: PLAY_API_TIMEOUT_MS,
         });
 
     const versionCodeUploaded = result.data.versionCode;

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -116,15 +116,15 @@ export class GooglePlay {
         });
 
     const versionCodeUploaded = result.data.versionCode;
-    if(!versionCodeUploaded) {
+    if (!versionCodeUploaded) {
       throw new Error('Version code could not be found from Play API.');
     }
-    const retainedBundlesStr = retainedBundles.map(n => n.toString());
+    const retainedBundlesStr = retainedBundles.map((n) => n.toString());
     await this.addBundleToTrack(
         track,
         [versionCodeUploaded.toString(), ...retainedBundlesStr],
         packageName,
-      editId,
+        editId,
     );
     await this._googlePlayApi.edits.commit(
         {
@@ -187,7 +187,7 @@ export class GooglePlay {
     }
     const bundleResponse =
       await this._googlePlayApi.edits.bundles.list({packageName: packageName, editId: editId});
-    if(!bundleResponse.data.bundles){
+    if (!bundleResponse.data.bundles) {
       throw new Error('No bundles found from Google Play');
     }
     const versionCode = Math.max(


### PR DESCRIPTION
This adds the capability to publish a bundle using the API directly
rather than depending on a gradle task.