### PR TITLE
Remove init command.

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -27,7 +27,6 @@ import {enUS} from '../strings';
 
 export interface PlayArgs {
   publish?: string;
-  init?: boolean;
   serviceAccountFile?: string;
   manifest?: string;
   appBundleLocation?: string;
@@ -44,14 +43,6 @@ class Play {
     private googlePlay: GooglePlay,
     private prompt: Prompt = new InquirerPrompt(),
   ) {}
-
-  /**
-  * Bootstraps the Play listing via the Gradle-Play-Plugin.
-  * @return {void}
-  */
-  async bootstrapPlay(): Promise<void> {
-    await this.googlePlay.initPlay();
-  }
 
   /**
   * @summary Can validate the largest version number vs twa-manifest.json and update
@@ -140,11 +131,6 @@ class Play {
     if (!this.validServiceAccountJsonFile(twaManifest.serviceAccountJsonFile)) {
       this.prompt.printMessage(enUS.messageServiceAccountJSONMissing);
       return false;
-    }
-
-    // bubblewrap play --init
-    if (this.args.init) {
-      await this.bootstrapPlay();
     }
 
     // bubblewrap play --versionCheck

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -48,15 +48,6 @@ export class GooglePlay {
   }
 
   /**
-   * Initialized Google Play and loads the existing configruation from Google Play.
-   * The resulting files are stored in the play folder in the src directory.
-   * https://github.com/Triple-T/gradle-play-publisher#quickstart
-   */
-  async initPlay(): Promise<void> {
-    await this.gradleWrapper.executeGradleCommand(['bootstrap']);
-  }
-
-  /**
    * This calls the publish bundle command and publishes an existing artifact to Google
    * Play.
    * https://github.com/Triple-T/gradle-play-publisher#uploading-a-pre-existing-artifact


### PR DESCRIPTION
The gradle bootstrapPlay command was extraneous. It synced the play
representation down in a file format that could be looked over. This
provided no benefit to the end user.