### PR TITLE
Adjust the CLI to not use any Gradle cmds.

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -89,7 +89,7 @@ export class Cli {
       case 'fingerprint':
         return await fingerprint(parsedArgs);
       // case 'play':
-      //   return await play(config, parsedArgs as unknown as PlayArgs);
+      //   return await play(parsedArgs as unknown as PlayArgs);
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -44,7 +44,7 @@ export class GooglePlay {
    * @param serviceAccountJsonFilePath This is the service account file to communicate with the
    *   play publisher API.
    */
-  constructor(private gradleWrapper: GradleWrapper, serviceAccountJsonFilePath?: string) {
+  constructor(private gradleWrapper?: GradleWrapper, serviceAccountJsonFilePath?: string) {
     if (serviceAccountJsonFilePath) {
       this._googlePlayApi = this.getAndroidClient(serviceAccountJsonFilePath);
     }
@@ -58,7 +58,7 @@ export class GooglePlay {
    */
   async publishBundleWithGradle(track: PlayStoreTrack, filepath: string): Promise<void> {
     // Uploads the artifact to the default internal track.
-    await this.gradleWrapper.executeGradleCommand(
+    await this.gradleWrapper?.executeGradleCommand(
         ['publishBundle', '--artifact-dir', filepath, '--track', track]);
   }
 


### PR DESCRIPTION
This adjusts the CLI to not use any Gradle commands and only uses the
Play Publisher API commands. In a future CL, we will remove all the
gradle play publisher commands as they are no longer needed.