### PR TITLE
Revert billing dependency

### DIFF
--- a/packages/core/src/lib/features/PlayBillingFeature.ts
+++ b/packages/core/src/lib/features/PlayBillingFeature.ts
@@ -24,7 +24,7 @@ export class PlayBillingFeature extends EmptyFeature {
   constructor() {
     super('playbilling');
 
-    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.0.0-alpha08');
+    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.0.0-alpha07');
 
     this.androidManifest.components.push(`
         <activity


### PR DESCRIPTION
Play Billing UI is not showing up since bumping the dependency. While it gets resolved in android-browser-helper, revert the version for now.