### PR TITLE
Add retain bundles feature

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -134,14 +134,10 @@ class Play {
         throw new Error(enUS.versionRetainedNotAnInteger);
       }
       if (versionToRetain > twaManifest.appVersionCode) {
-        // Cannot retain a higher version as that would take presendence.
-        const approveVersionDifference =
-          await this.prompt.promptConfirm(
+        // Cannot retain a higher version as that would take precedence.
+          await this.prompt.printMessage(
               enUS.versionToRetainHigherThanBuildVersion(
-                  twaManifest.appVersionCode, versionToRetain), false);
-        if (!approveVersionDifference) {
-          return false;
-        }
+                  twaManifest.appVersionCode, versionToRetain));
       }
       // Validate that the version exists on the Play Servers.
       if (!this.googlePlay.versionExists(twaManifest.packageId, versionToRetain)) {

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -135,9 +135,9 @@ class Play {
       }
       if (versionToRetain > twaManifest.appVersionCode) {
         // Cannot retain a higher version as that would take precedence.
-          await this.prompt.printMessage(
-              enUS.versionToRetainHigherThanBuildVersion(
-                  twaManifest.appVersionCode, versionToRetain));
+        await this.prompt.printMessage(
+            enUS.versionToRetainHigherThanBuildVersion(
+                twaManifest.appVersionCode, versionToRetain));
       }
       // Validate that the version exists on the Play Servers.
       if (!this.googlePlay.versionExists(twaManifest.packageId, versionToRetain)) {

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -137,7 +137,8 @@ class Play {
         // Cannot retain a higher version as that would take presendence.
         const approveVersionDifference =
           await this.prompt.promptConfirm(
-            enUS.versionToRetainHigherThanBuildVersion(twaManifest.appVersionCode, versionToRetain), false);
+              enUS.versionToRetainHigherThanBuildVersion(
+                  twaManifest.appVersionCode, versionToRetain), false);
         if (!approveVersionDifference) {
           return false;
         }
@@ -148,24 +149,24 @@ class Play {
       }
 
       twaManifest.retainedBundles.push(versionToRetain);
-      
+
       await twaManifest.saveToFile(manifestFile);
     }
 
     // bubblewrap play --removeRetained 86
     if (this.args.removeRetained) {
       const versionToRemove = this.args.removeRetained;
-      twaManifest.retainedBundles.filter(obj => {
+      twaManifest.retainedBundles.filter((obj) => {
         return obj != versionToRemove;
-      })
+      });
       await twaManifest.saveToFile(manifestFile);
     }
 
     // bubblewrap play --listRetained
     if (this.args.listRetained) {
-      twaManifest.retainedBundles.forEach(version => {
+      twaManifest.retainedBundles.forEach((version) => {
         this.prompt.printMessage(`${version}`);
-      })
+      });
     }
 
     // bubblewrap play --publish

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -128,6 +128,9 @@ type Messages = {
   jdkIsNotSupported: string;
   androidSdkPathIsNotCorrect: string;
   bothPathsAreValid: string;
+  versionDoesNotExistOnServer: string;
+  versionToRetainHigherThanBuildVersion: (currentVersion: number, versionToRetain: number) => string;
+  versionRetainedNotAnInteger: string;
 }
 
 export const enUS: Messages = {
@@ -406,4 +409,11 @@ the PWA:
       'command to update it:\nbubblewrap updateConfig --androidSdkPath <path-to-sdk>, such that ' +
       'the folder of the path contains the folder "build". Then run bubblewrap doctor again.',
   bothPathsAreValid: 'Your jdkpath and androidSdkPath are valid.',
+  versionDoesNotExistOnServer: 'The supplied version code does not exist on Google Plays Servers.',
+  versionToRetainHigherThanBuildVersion: (currentVersion: number, versionToRetain: number): string => {
+    return `The version to retain (${cyan(versionToRetain.toString())}) is currently higher than
+    the current version you want to publish (${cyan(currentVersion.toString())}). Do you want to
+    continue?`;
+  },
+  versionRetainedNotAnInteger: 'The retained version code must be an integer.',
 };

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -411,7 +411,7 @@ the PWA:
       'the folder of the path contains the folder "build". Then run bubblewrap doctor again.',
   bothPathsAreValid: 'Your jdkpath and androidSdkPath are valid.',
   versionDoesNotExistOnServer: 'The supplied version code does not exist on the Google Play' +
-    'Servers.',
+    ' Servers.',
   versionToRetainHigherThanBuildVersion:
     (currentVersion: number, versionToRetain: number): string => {
       return `The version to retain (${cyan(versionToRetain.toString())}) is currently higher than

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -129,7 +129,8 @@ type Messages = {
   androidSdkPathIsNotCorrect: string;
   bothPathsAreValid: string;
   versionDoesNotExistOnServer: string;
-  versionToRetainHigherThanBuildVersion: (currentVersion: number, versionToRetain: number) => string;
+  versionToRetainHigherThanBuildVersion:
+    (currentVersion: number, versionToRetain: number) => string;
   versionRetainedNotAnInteger: string;
 }
 
@@ -410,10 +411,11 @@ the PWA:
       'the folder of the path contains the folder "build". Then run bubblewrap doctor again.',
   bothPathsAreValid: 'Your jdkpath and androidSdkPath are valid.',
   versionDoesNotExistOnServer: 'The supplied version code does not exist on Google Plays Servers.',
-  versionToRetainHigherThanBuildVersion: (currentVersion: number, versionToRetain: number): string => {
-    return `The version to retain (${cyan(versionToRetain.toString())}) is currently higher than
-    the current version you want to publish (${cyan(currentVersion.toString())}). Do you want to
-    continue?`;
-  },
+  versionToRetainHigherThanBuildVersion:
+    (currentVersion: number, versionToRetain: number): string => {
+      return `The version to retain (${cyan(versionToRetain.toString())}) is currently higher than
+      the current version you want to publish (${cyan(currentVersion.toString())}). Do you want to
+      continue?`;
+    },
   versionRetainedNotAnInteger: 'The retained version code must be an integer.',
 };

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -410,12 +410,12 @@ the PWA:
       'command to update it:\nbubblewrap updateConfig --androidSdkPath <path-to-sdk>, such that ' +
       'the folder of the path contains the folder "build". Then run bubblewrap doctor again.',
   bothPathsAreValid: 'Your jdkpath and androidSdkPath are valid.',
-  versionDoesNotExistOnServer: 'The supplied version code does not exist on Google Plays Servers.',
+  versionDoesNotExistOnServer: 'The supplied version code does not exist on the Google Play' +
+    'Servers.',
   versionToRetainHigherThanBuildVersion:
     (currentVersion: number, versionToRetain: number): string => {
       return `The version to retain (${cyan(versionToRetain.toString())}) is currently higher than
-      the current version you want to publish (${cyan(currentVersion.toString())}). Do you want to
-      continue?`;
+      the current version you want to publish (${cyan(currentVersion.toString())}).`;
     },
   versionRetainedNotAnInteger: 'The retained version code must be an integer.',
 };

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -149,16 +149,16 @@ export class GooglePlay {
     }
     const versionCode = Math.max(
         ...bundleResponse.data.bundles.map((bundle) => bundle.versionCode!!));
-    
+
     await this.endPlayOperation(packageName, editId);
-    
+
     return versionCode;
   }
 
   /**
    * Starts an edit on the Play servers. This is the basis for any play publishing api operation.
    * @param packageName - the packageName of the app we want to interact with.
-   * 
+   *
    */
   private async startPlayOperation(packageName: string): Promise<string> {
     const edit = await this._googlePlayApi.edits.insert({packageName: packageName});
@@ -182,7 +182,7 @@ export class GooglePlay {
    * Checks to see if the version that we want to retain already exists within the Play Store.
    * @param packageName - The packageName of the versionCode we are looking up.
    * @param versionCode - The version code of the APK / Bundle we want to retain.
-   * 
+   *
    */
   async versionExists(packageName: string, versionCode: number): Promise<boolean> {
     const editId = await this.startPlayOperation(packageName);
@@ -190,23 +190,22 @@ export class GooglePlay {
     const uploadedApks =
       await this._googlePlayApi.edits.apks.list({packageName: packageName, editId: editId});
 
-    uploadedApks.data.apks?.filter(async obj => {
-      if (obj.versionCode == versionCode) {
-        await this.endPlayOperation(packageName, editId);
-        return true;
-      }
-    })
+    let found = uploadedApks.data.apks?.find(async (obj) => obj.versionCode == versionCode);
+
+    if (found) {
+      await this.endPlayOperation(packageName, editId);
+      return true;
+    }
 
     const uploadedBundles =
       await this._googlePlayApi.edits.bundles.list({packageName: packageName, editId: editId});
 
-    uploadedBundles.data.bundles?.filter(async obj => {
-      if (obj.versionCode == versionCode) {
-        await this.endPlayOperation(packageName, editId);
-        return true;
-      }
-    })
+    found = uploadedBundles.data.bundles?.find(async (obj) => obj.versionCode == versionCode);
 
+    if (found) {
+      await this.endPlayOperation(packageName, editId);
+      return true;
+    }
 
     await this.endPlayOperation(packageName, editId);
     return false;

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -178,7 +178,6 @@ export class GooglePlay {
   /**
    * Starts an edit on the Play servers. This is the basis for any play publishing api operation.
    * @param packageName - the packageName of the app we want to interact with.
-   *
    */
   private async startPlayOperation(packageName: string): Promise<string> {
     const edit = await this._googlePlayApi.edits.insert({packageName: packageName});
@@ -202,7 +201,6 @@ export class GooglePlay {
    * Checks to see if the version that we want to retain already exists within the Play Store.
    * @param packageName - The packageName of the versionCode we are looking up.
    * @param versionCode - The version code of the APK / Bundle we want to retain.
-   *
    */
   async versionExists(packageName: string, versionCode: number, editId: string):
       Promise<PlayOperationResult> {
@@ -211,7 +209,7 @@ export class GooglePlay {
     const uploadedApks =
         await this._googlePlayApi.edits.apks.list({packageName: packageName, editId: editId});
 
-    let found = uploadedApks.data.apks?.find(async (obj) => obj.versionCode == versionCode);
+    let found = uploadedApks.data.apks?.find((obj) => obj.versionCode == versionCode);
 
     if (found) {
       playOpsResult.versionExistsResult = true;

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -196,7 +196,6 @@ export class GooglePlay {
    */
   async versionExists(packageName: string, versionCode: number, editId: string):
       Promise<boolean> {
-
     const uploadedApks =
         await this._googlePlayApi.edits.apks.list({packageName: packageName, editId: editId});
 

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -158,6 +158,7 @@ export class TwaManifest {
   fingerprints: Fingerprint[];
   serviceAccountJsonFile: string | undefined;
   additionalTrustedOrigins: string[];
+  retainedBundles: number[];
 
   private static log = new ConsoleLog('twa-manifest');
 
@@ -203,6 +204,7 @@ export class TwaManifest {
     this.fingerprints = data.fingerprints || [];
     this.serviceAccountJsonFile = data.serviceAccountJsonFile;
     this.additionalTrustedOrigins = data.additionalTrustedOrigins || [];
+    this.retainedBundles = data.retainedBundles || [];
   }
 
   /**
@@ -528,6 +530,7 @@ export interface TwaManifestJson {
   fingerprints?: Fingerprint[];
   serviceAccountJsonFile?: string;
   additionalTrustedOrigins?: string[];
+  retainedBundles?: number[];
 }
 
 export interface SigningKeyInfo {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -224,7 +224,7 @@ describe('TwaManifest', () => {
         isChromeOSOnly: false,
         serviceAccountJsonFile: '/home/service-account.json',
         additionalTrustedOrigins: ['test.com'],
-        retainedBundles: [3,4,5],
+        retainedBundles: [3, 4, 5],
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
@@ -257,7 +257,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.isChromeOSOnly).toEqual(false);
       expect(twaManifest.serviceAccountJsonFile).toEqual(twaManifestJson.serviceAccountJsonFile);
       expect(twaManifest.additionalTrustedOrigins).toEqual(['test.com']);
-      expect(twaManifest.retainedBundles).toEqual([3,4,5]);
+      expect(twaManifest.retainedBundles).toEqual([3, 4, 5]);
     });
 
     it('Sets correct default values for optional fields', () => {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -116,6 +116,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.shortcuts).toEqual([]);
       expect(twaManifest.generateShortcuts()).toBe('[]');
       expect(twaManifest.additionalTrustedOrigins).toEqual([]);
+      expect(twaManifest.retainedBundles).toEqual([]);
     });
 
     it('Uses "name" when "short_name" is not available', () => {
@@ -223,6 +224,7 @@ describe('TwaManifest', () => {
         isChromeOSOnly: false,
         serviceAccountJsonFile: '/home/service-account.json',
         additionalTrustedOrigins: ['test.com'],
+        retainedBundles: [3,4,5],
       } as TwaManifestJson;
       const twaManifest = new TwaManifest(twaManifestJson);
       expect(twaManifest.packageId).toEqual(twaManifestJson.packageId);
@@ -255,6 +257,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.isChromeOSOnly).toEqual(false);
       expect(twaManifest.serviceAccountJsonFile).toEqual(twaManifestJson.serviceAccountJsonFile);
       expect(twaManifest.additionalTrustedOrigins).toEqual(['test.com']);
+      expect(twaManifest.retainedBundles).toEqual([3,4,5]);
     });
 
     it('Sets correct default values for optional fields', () => {


### PR DESCRIPTION
This adds the retain bundles feature to the Google Play integration.
This allows users when trying to publish an Android App bundle the
ability to select which bundles they would like to retain. This is
important for when a developer wants to release a ChromeOS only release
alongside an Android release.