### PR TITLE
Improves escaping for shell commands

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -296,3 +296,11 @@ export function toAndroidScreenOrientation(orientation: Orientation): string {
 export function escapeGradleString(input: string): string {
   return input.replace(/[\\']/g, '\\\\\\$&');
 }
+
+/**
+ * Escapes a string that will be used inside a double quoted block in the shell. The characters
+ * ", $, `, and \ need escaping even when the string is surrounded by double quotes.  
+ */
+export function escapeDoubleQuotedShellString(input: string): string {
+  return input.replace(/([\$"`\\])/g, '\\$1');
+} 

--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -299,8 +299,8 @@ export function escapeGradleString(input: string): string {
 
 /**
  * Escapes a string that will be used inside a double quoted block in the shell. The characters
- * ", $, `, and \ need escaping even when the string is surrounded by double quotes.  
+ * ", $, `, and \ need escaping even when the string is surrounded by double quotes.
  */
 export function escapeDoubleQuotedShellString(input: string): string {
   return input.replace(/([\$"`\\])/g, '\\$1');
-} 
+}

--- a/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
+++ b/packages/core/src/spec/lib/jdk/KeyToolSpec.ts
@@ -58,8 +58,8 @@ describe('KeyTool', () => {
       alias: 'keyalias',
       keypassword: 'keypass',
       password: 'pass',
-      fullName: 'Test, User',
-      organization: 'Test, Organization',
+      fullName: 'Test, Us`er',
+      organization: 'Test, Organization$',
       organizationalUnit: 'Tes,ters',
       country: 'GB',
     } as CreateKeyOptions;
@@ -72,8 +72,8 @@ describe('KeyTool', () => {
       expect(util.execute).toHaveBeenCalledWith([
         'keytool',
         '-genkeypair',
-        '-dname "cn=Test\\, User, ou=Tes\\,ters, ' +
-            `o=Test\\, Organization, c=${keyOptions.country}"`,
+        '-dname "cn=Test\\, Us\\`er, ou=Tes\\,ters, ' +
+            `o=Test\\, Organization\\$, c=${keyOptions.country}"`,
         `-alias "${keyOptions.alias}"`,
         `-keypass "${keyOptions.keypassword}"`,
         `-keystore "${keyOptions.path}"`,

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -297,4 +297,11 @@ describe('util', () => {
           .toEqual('Backwards slash \\\\\\\\');
     });
   });
+
+  describe('#escapeDoubleQuotedShellString', () => {
+    it('Escapes \\, `, $, and "', () => {
+      expect(util.escapeDoubleQuotedShellString('"$Hello\\Wo`eld"'))
+          .toEqual('\\"\\$Hello\\\\Wo\\`eld\\"');
+    });
+  });
 });


### PR DESCRIPTION
The ", $, `, and \ characters still needs to be escaped in double
quoted parameters for shell commands. Those are better handled
in this PR.

Fixes #587