### PR TITLE
Support changing the versionName on versionCheck.

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -126,6 +126,9 @@ class Play {
         const updateVersion = await this.prompt.promptConfirm(enUS.promptVersionMismatch(
             twaManifest.appVersionCode.toString(), version.toString()), true);
         if (updateVersion) {
+          if (twaManifest.appVersionCode.toString() == twaManifest.appVersionName) {
+            twaManifest.appVersionName = (version+1).toString();
+          }
           twaManifest.appVersionCode = version + 1;
           await twaManifest.saveToFile(manifestFile);
           await this.updateProjectAndWarn(manifestFile);

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -127,7 +127,7 @@ class Play {
             twaManifest.appVersionCode.toString(), version.toString()), true);
         if (updateVersion) {
           if (twaManifest.appVersionCode.toString() == twaManifest.appVersionName) {
-            twaManifest.appVersionName = (version+1).toString();
+            twaManifest.appVersionName = (version + 1).toString();
           }
           twaManifest.appVersionCode = version + 1;
           await twaManifest.saveToFile(manifestFile);


### PR DESCRIPTION
This supports changing the app version name on version checks if it
matches the version code listed in twa-manifest.json.