### PR TITLE
Fixes versionExists issue and extra error message.

### DIFF
--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -87,7 +87,7 @@ class Play {
         async (editId: string): Promise<void> => {
           return await this.googlePlay.publishBundle(
               userSelectedTrack, publishFilePath, twaManifest.packageId, retainedBundles, editId);
-        });
+        }, true);
 
     return true;
   }
@@ -156,7 +156,12 @@ class Play {
         throw new Error(enUS.versionDoesNotExistOnServer);
       }
 
-      twaManifest.retainedBundles.push(versionToRetain);
+      const alreadyRetained = twaManifest.retainedBundles.find(
+          (version) => version == versionToRetain);
+
+      if (!alreadyRetained) {
+        twaManifest.retainedBundles.push(versionToRetain);
+      }
 
       await twaManifest.saveToFile(manifestFile);
     }

--- a/packages/core/src/lib/GooglePlay.ts
+++ b/packages/core/src/lib/GooglePlay.ts
@@ -52,13 +52,16 @@ export class GooglePlay {
    * Generates an editId that should be used in all play operations.
    * @param packageName - The package that will be worked upon.
    * @param operation - The Play Operation which requires an editId injected
+   * @param commitEdit - Whether or not this edit is a action or query edit. true indicates an action edit.
    * @returns - A PlayOperationResult which contains the output of the operation in a field that was worked upon.
    */
   async performPlayOperation<Type>(packageName: string,
-      operation: (editId: string) => Promise<Type>): Promise<Type> {
+      operation: (editId: string) => Promise<Type>, commitEdit = false): Promise<Type> {
     const editId = await this.startPlayOperation(packageName);
     const result = await operation(editId);
-    await this.endPlayOperation(packageName, editId);
+    if (!commitEdit) {
+      await this.endPlayOperation(packageName, editId);
+    }
     return result;
   }
 
@@ -208,7 +211,7 @@ export class GooglePlay {
     const uploadedBundles =
         await this._googlePlayApi.edits.bundles.list({packageName: packageName, editId: editId});
 
-    found = uploadedBundles.data.bundles?.find(async (obj) => obj.versionCode == versionCode);
+    found = uploadedBundles.data.bundles?.find((obj) => obj.versionCode == versionCode);
 
     if (found) {
       return true;


### PR DESCRIPTION
Removed the asynchronous find method as it was returning true when it
should have returned false. Additionally, added a flag to
performPlayOperation to prevent an error message from appearing when we
commit an edit rather than create a query edit. Also fix duplicate
retain versions from existing in retainBundles.