### PR TITLE
Support and use targetSdk 31

### DIFF
--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -23,8 +23,8 @@ import {FirstRunFlagFeature} from './FirstRunFlagFeature';
 import {Log, ConsoleLog} from '../Log';
 
 const ANDROID_BROWSER_HELPER_VERSIONS = {
-  stable: 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.1',
-  alpha: 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.1',
+  stable: 'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0',
+  alpha: 'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0',
 };
 
 /**

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -75,7 +75,7 @@ describe('FeatureManager', () => {
       expect(features.applicationClass.onCreate).toEqual([]);
       expect(features.applicationClass.variables).toEqual([]);
       expect(features.buildGradle.dependencies).toContain(
-          'com.google.androidbrowserhelper:androidbrowserhelper:2.2.1');
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0');
       expect(features.buildGradle.repositories).toEqual(emptySet);
       expect(features.launcherActivity.imports).toEqual(emptySet);
       expect(features.launcherActivity.launchUrl).toEqual([]);
@@ -90,7 +90,7 @@ describe('FeatureManager', () => {
       } as TwaManifest;
       const features = new FeatureManager(manifest);
       expect(features.buildGradle.dependencies).toContain(
-          'com.google.androidbrowserhelper:androidbrowserhelper:2.2.1');
+          'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0');
     });
 
     it('Adds INTERNET permission when WebView fallback is enabled', () => {

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -53,11 +53,11 @@ def twaManifest = [
 ]
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "<%= packageId %>"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode <%= appVersionCode %>
         versionName "<%= appVersionName %>"
 

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
 
         <activity android:name="LauncherActivity"
             android:alwaysRetainTaskState="true"
-            android:label="@string/launcherName">
+            android:label="@string/launcherName"
+            android:exported="true">
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"
                 android:value="@string/launchUrl" />
 


### PR DESCRIPTION
- Updates to android-browser-helper 2.3.0
- Adds android:exported to LauncherActivity
- Updates app/build.gradle to targetSdk 31