### PR TITLE
Adds the ArCore feature

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -27,6 +27,7 @@ import {AppsFlyerConfig} from './features/AppsFlyerFeature';
 import {LocationDelegationConfig} from './features/LocationDelegationFeature';
 import {PlayBillingConfig} from './features/PlayBillingFeature';
 import {FirstRunFlagConfig} from './features/FirstRunFlagFeature';
+import {ArCoreConfig} from './features/ArCoreFeature';
 
 // The minimum size needed for the app icon.
 const MIN_ICON_SIZE = 512;
@@ -83,6 +84,7 @@ type Features = {
   locationDelegation?: LocationDelegationConfig;
   playBilling?: PlayBillingConfig;
   firstRunFlag?: FirstRunFlagConfig;
+  arCore?: ArCoreConfig;
 };
 
 type alphaDependencies = {
@@ -404,7 +406,7 @@ export class TwaManifest {
           shortcuts.push(shortcutInfo);
         }
       } catch (err) {
-        TwaManifest.log.warn(`Skipping shortcut[${i}] for ${err.message}.`);
+        TwaManifest.log.warn(`Skipping shortcut[${i}] for ${err}.`);
       }
       if (shortcuts.length === 4) {
         break;
@@ -517,6 +519,7 @@ export interface TwaManifestJson {
     locationDelegation?: LocationDelegationConfig;
     playBilling?: PlayBillingConfig;
     firstRunFlag?: FirstRunFlagConfig;
+    arCore?: ArCoreConfig;
   };
   alphaDependencies?: {
     enabled: boolean;

--- a/packages/core/src/lib/features/ArCoreFeature.ts
+++ b/packages/core/src/lib/features/ArCoreFeature.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {EmptyFeature} from './EmptyFeature';
+import {Metadata} from './Feature';
+
+export interface ArCoreConfig {
+  enabled: boolean;
+}
+
+export class ArCoreFeature extends EmptyFeature {
+  constructor() {
+    super('ArCoreFeature');
+    this.androidManifest.applicationMetadata.push(new Metadata('com.google.ar.core', 'required'));
+  }
+}

--- a/packages/core/src/lib/features/EmptyFeature.ts
+++ b/packages/core/src/lib/features/EmptyFeature.ts
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import {Feature} from './Feature';
+import {Feature, Metadata} from './Feature';
 
 export class EmptyFeature implements Feature {
   name: string;
@@ -29,9 +29,11 @@ export class EmptyFeature implements Feature {
   androidManifest: {
     permissions: string[];
     components: string[];
+    applicationMetadata: Metadata[];
   } = {
     permissions: new Array<string>(),
     components: new Array<string>(),
+    applicationMetadata: new Array<Metadata>(),
   };
 
   applicationClass: {

--- a/packages/core/src/lib/features/Feature.ts
+++ b/packages/core/src/lib/features/Feature.ts
@@ -14,6 +14,10 @@
  *  limitations under the License.
  */
 
+export class Metadata {
+  constructor(public readonly name: string, public readonly value: string) {};
+}
+
 /**
  * Specifies a set of customizations to be applied when generating the Android project
  * in order to enable a feature.
@@ -61,6 +65,10 @@ export interface Feature {
      * ```
      */
     components: string[];
+    /**
+     * Additional meta-data items to be added into the `application` tag.
+     */
+    applicationMetadata: Metadata[];
   };
   /**
    * Customizations to be added to `app/src/main/java/<app-package>/Application.java`.

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -14,13 +14,14 @@
  *  limitations under the License.
  */
 
-import {Feature} from './Feature';
+import {Feature, Metadata} from './Feature';
 import {AppsFlyerFeature} from './AppsFlyerFeature';
 import {LocationDelegationFeature} from './LocationDelegationFeature';
 import {PlayBillingFeature} from './PlayBillingFeature';
 import {TwaManifest} from '../TwaManifest';
 import {FirstRunFlagFeature} from './FirstRunFlagFeature';
 import {Log, ConsoleLog} from '../Log';
+import {ArCoreFeature} from './ArCoreFeature';
 
 const ANDROID_BROWSER_HELPER_VERSIONS = {
   stable: 'com.google.androidbrowserhelper:androidbrowserhelper:2.3.0',
@@ -39,6 +40,7 @@ export class FeatureManager {
   androidManifest = {
     permissions: new Set<string>(),
     components: new Array<string>(),
+    applicationMetadata: new Array<Metadata>(),
   };
   applicationClass = {
     imports: new Set<string>(),
@@ -91,6 +93,10 @@ export class FeatureManager {
     } else {
       this.buildGradle.dependencies.add(ANDROID_BROWSER_HELPER_VERSIONS.stable);
     }
+
+    if (twaManifest.features.arCore?.enabled) {
+      this.addFeature(new ArCoreFeature());
+    }
   }
 
   private addFeature(feature: Feature): void {
@@ -121,6 +127,10 @@ export class FeatureManager {
 
     feature.androidManifest.components.forEach((component) => {
       this.androidManifest.components.push(component);
+    });
+
+    feature.androidManifest.applicationMetadata.forEach((metadata) => {
+      this.androidManifest.applicationMetadata.push(metadata);
     });
 
     // Adds properties to launcherActivity.

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -55,6 +55,12 @@
             android:name="twa_generator"
             android:value="@string/generatorApp" />
 
+        <% for (const metadata of androidManifest.applicationMetadata) {%>
+            <meta-data
+                android:name="<%= metadata.name %>"
+                android:value="<%= metadata.value %>" />
+        <% } %>
+
         <% if (enableSiteSettingsShortcut) { %>
             <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
             <meta-data


### PR DESCRIPTION
- Adds a feature that appends the AR Core requirement to the
  AndroidManifest, ensuring the app is only deployed to devices that
  support ARCore.

Closes #515