### PR TITLE
Create playPublish command.

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -92,7 +92,7 @@ export class Cli {
       // case 'play':
       //   return await play(parsedArgs as unknown as PlayArgs);
       // case 'playPublish':
-      //   return await playPublish(parsedArgs as unknown as PlayArgs);
+      //   return await play(parsedArgs as unknown as PlayArgs, 'publish');
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -31,6 +31,7 @@ import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
 // import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
+// import { play, PlayArgs, playPublish } from './cmds/play';
 
 export class Cli {
   async run(args: string[]): Promise<boolean> {
@@ -90,6 +91,8 @@ export class Cli {
         return await fingerprint(parsedArgs);
       // case 'play':
       //   return await play(parsedArgs as unknown as PlayArgs);
+      // case 'playPublish':
+      //   return await playPublish(parsedArgs as unknown as PlayArgs);
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -37,6 +37,8 @@ export interface PlayArgs {
 // Default file path
 const defaultSignedAppBundleFileName = 'app-release-bundle.aab';
 
+type PlayCommand = 'publish' | 'retain' | 'versionCheck';
+
 /**
   * The Play class is the class that is used to communicate with the Google Play Store.
   */
@@ -238,24 +240,16 @@ async function setupGooglePlay(args: PlayArgs): Promise<GooglePlay> {
   return new GooglePlay(twaManifest.serviceAccountJsonFile);
 }
 
-export async function playPublish(parsedArgs: PlayArgs,
-    prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
-  // TODO(@nohe427): Remove after experimental
-  if (!await prompt.promptConfirm(enUS.promptExperimentalFeature, false)) {
-    return true;
-  }
-  const googlePlay = await setupGooglePlay(parsedArgs);
-  const play = new Play(parsedArgs, googlePlay, prompt);
-  return await play.runPlayPublish();
-}
-
 export async function play(parsedArgs: PlayArgs,
-    prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
+    command: PlayCommand, prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
   // TODO(@nohe427): Remove after experimental
   if (!await prompt.promptConfirm(enUS.promptExperimentalFeature, false)) {
     return true;
   }
   const googlePlay = await setupGooglePlay(parsedArgs);
   const play = new Play(parsedArgs, googlePlay, prompt);
+  if (command == 'publish') {
+    return await play.runPlayPublish();
+  }
   return await play.run();
 }

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -23,7 +23,7 @@ import {updateProject} from './shared';
 import {enUS} from '../strings';
 
 export interface PlayArgs {
-  publish?: string;
+  track?: string;
   serviceAccountFile?: string;
   manifest?: string;
   appBundleLocation?: string;
@@ -68,7 +68,7 @@ class Play {
   async publish(twaManifest: TwaManifest): Promise<boolean> {
     // Validate that the publish value is listed in the available Tracks.
     // If no value was supplied with publish we make it internal.
-    const userSelectedTrack = asPlayStoreTrack(this.args.publish?.toLowerCase() || 'internal');
+    const userSelectedTrack = asPlayStoreTrack(this.args.track?.toLowerCase() || 'internal');
     if (userSelectedTrack == null) {
       this.prompt.printMessage(enUS.messageInvalidTrack);
       return false;
@@ -113,9 +113,6 @@ class Play {
   * @return {boolean} Returns whether or not the run command completed successfully.
   */
   async run(): Promise<boolean> {
-    if (!await this.prompt.promptConfirm(enUS.promptExperimentalFeature, false)) {
-      return true;
-    }
     const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
     const twaManifest = await TwaManifest.fromFile(manifestFile);
 
@@ -185,16 +182,25 @@ class Play {
       });
     }
 
-    // bubblewrap play --publish
-    if (this.args.publish) {
-      const success = await this.publish(twaManifest);
-      if (!success) {
-        this.prompt.printMessage(enUS.messagePublishingWasNotSuccessful);
-        return false;
-      }
-      this.prompt.printMessage(enUS.messagePlayUploadSuccess);
-    }
+    return true;
+  }
 
+  /**
+   * Calls the publish workflow to the Play Store. This takes a user supplied track (or internal)
+   *  and an appBundleLocation (defaults to the current directory) and uploads these artifacts to
+   *  the Google Play Store.
+   * @returns whether the playPublish command completed successfully
+   */
+  async runPlayPublish(): Promise<boolean> {
+    const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
+    const twaManifest = await TwaManifest.fromFile(manifestFile);
+
+    const success = await this.publish(twaManifest);
+    if (!success) {
+      this.prompt.printMessage(enUS.messagePublishingWasNotSuccessful);
+      return false;
+    }
+    this.prompt.printMessage(enUS.messagePlayUploadSuccess);
     return true;
   }
 }
@@ -232,10 +238,24 @@ async function setupGooglePlay(args: PlayArgs): Promise<GooglePlay> {
   return new GooglePlay(twaManifest.serviceAccountJsonFile);
 }
 
-export async function play(parsedArgs: PlayArgs,
+export async function playPublish(parsedArgs: PlayArgs,
     prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
+  // TODO(@nohe427): Remove after experimental
+  if (!await prompt.promptConfirm(enUS.promptExperimentalFeature, false)) {
+    return true;
+  }
   const googlePlay = await setupGooglePlay(parsedArgs);
   const play = new Play(parsedArgs, googlePlay, prompt);
-  await play.run();
-  return true;
+  return await play.runPlayPublish();
+}
+
+export async function play(parsedArgs: PlayArgs,
+    prompt: Prompt = new InquirerPrompt()): Promise<boolean> {
+  // TODO(@nohe427): Remove after experimental
+  if (!await prompt.promptConfirm(enUS.promptExperimentalFeature, false)) {
+    return true;
+  }
+  const googlePlay = await setupGooglePlay(parsedArgs);
+  const play = new Play(parsedArgs, googlePlay, prompt);
+  return await play.run();
 }


### PR DESCRIPTION
This creates the playPublish command rather than the all in one play
command. This is a series of changes to complete migrating the commands
out to a less confusing state for our users.
See Google Play Integration #618

Fixes: Migrate play command to playPublish command #619