### PR TITLE
Migrate versionCheck to its own command.

### DIFF
--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -31,7 +31,6 @@ import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
 // import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
-import { play, PlayArgs } from './cmds/play';
 // import { play, PlayArgs, playPublish } from './cmds/play';
 
 export class Cli {

--- a/packages/cli/src/lib/Cli.ts
+++ b/packages/cli/src/lib/Cli.ts
@@ -31,6 +31,7 @@ import {merge} from './cmds/merge';
 import {fingerprint} from './cmds/fingerprint';
 // import {play, PlayArgs} from './cmds/play';
 import {fetchUtils} from '@bubblewrap/core';
+import { play, PlayArgs } from './cmds/play';
 // import { play, PlayArgs, playPublish } from './cmds/play';
 
 export class Cli {
@@ -93,6 +94,8 @@ export class Cli {
       //   return await play(parsedArgs as unknown as PlayArgs);
       // case 'playPublish':
       //   return await play(parsedArgs as unknown as PlayArgs, 'publish');
+      // case 'playVersionCheck':
+      //     return await play(parsedArgs as unknown as PlayArgs, 'versionCheck');
       default:
         throw new Error(
             `"${command}" is not a valid command! Use 'bubblewrap help' for a list of commands`);

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -28,7 +28,6 @@ export interface PlayArgs {
   manifest?: string;
   appBundleLocation?: string;
   targetDirectory?: string;
-  versionCheck?: boolean;
   retain?: number;
   removeRetained?: number;
   listRetained?: boolean;
@@ -119,23 +118,6 @@ class Play {
     const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
     const twaManifest = await TwaManifest.fromFile(manifestFile);
 
-    // bubblewrap play --versionCheck
-    if (this.args.versionCheck) {
-      const version = await this.getLargestVersion(twaManifest);
-      if (version >= twaManifest.appVersionCode) {
-        const updateVersion = await this.prompt.promptConfirm(enUS.promptVersionMismatch(
-            twaManifest.appVersionCode.toString(), version.toString()), true);
-        if (updateVersion) {
-          if (twaManifest.appVersionCode.toString() == twaManifest.appVersionName) {
-            twaManifest.appVersionName = (version + 1).toString();
-          }
-          twaManifest.appVersionCode = version + 1;
-          await twaManifest.saveToFile(manifestFile);
-          await this.updateProjectAndWarn(manifestFile);
-        }
-      }
-    }
-
     // bubblewrap play --retain 86
     if (this.args.retain) {
       const versionToRetain = this.args.retain;
@@ -196,6 +178,26 @@ class Play {
     }
 
     return true;
+  }
+
+  async versionCheck(): Promise<boolean> {
+    const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
+    const twaManifest = await TwaManifest.fromFile(manifestFile);
+
+    // bubblewrap playVersionCheck
+    const version = await this.getLargestVersion(twaManifest);
+    if (version >= twaManifest.appVersionCode) {
+      const updateVersion = await this.prompt.promptConfirm(enUS.promptVersionMismatch(
+          twaManifest.appVersionCode.toString(), version.toString()), true);
+      if (updateVersion) {
+        if (twaManifest.appVersionCode.toString() == twaManifest.appVersionName) {
+          twaManifest.appVersionName = (version + 1).toString();
+        }
+        twaManifest.appVersionCode = version + 1;
+        await twaManifest.saveToFile(manifestFile);
+        await this.updateProjectAndWarn(manifestFile);
+      }
+    }
   }
 }
 

--- a/packages/cli/src/lib/cmds/play.ts
+++ b/packages/cli/src/lib/cmds/play.ts
@@ -188,7 +188,11 @@ class Play {
     return true;
   }
 
-  async versionCheck(): Promise<boolean> {
+  /**
+   * Runs the version check workflow. If the published version is higher than that of the twaManifest,
+   *  we assume that the version that exists locally is needs to be updated to a higher version.
+   */
+  async runVersionCheck(): Promise<void> {
     const manifestFile = this.args.manifest || path.join(process.cwd(), TWA_MANIFEST_FILE_NAME);
     const twaManifest = await TwaManifest.fromFile(manifestFile);
 
@@ -250,8 +254,12 @@ export async function play(parsedArgs: PlayArgs,
   }
   const googlePlay = await setupGooglePlay(parsedArgs);
   const play = new Play(parsedArgs, googlePlay, prompt);
-  if (command == 'publish') {
-    return await play.runPlayPublish();
+  switch (command) {
+    case 'publish':
+      return await play.runPlayPublish();
+    case 'versionCheck':
+      await play.runVersionCheck();
+      return true;
   }
   return await play.run();
 }


### PR DESCRIPTION
This seperates versionchecking from a unified Play command into its
own versionCheck command.

Fixes #623 