### PR TITLE
Update JDK 8 to JDK 11

### DIFF
--- a/packages/cli/src/lib/JdkInstaller.ts
+++ b/packages/cli/src/lib/JdkInstaller.ts
@@ -19,19 +19,19 @@ import {util} from '@bubblewrap/core';
 import {Prompt} from './Prompt';
 import {enUS as messages} from './strings';
 
-const JDK_VERSION = '8u265-b01';
-const JDK_DIR = `jdk${JDK_VERSION}`;
-const DOWNLOAD_JDK_BIN_ROOT = `https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${JDK_VERSION}/`;
-const DOWNLOAD_JDK_SRC_ROOT = 'https://github.com/AdoptOpenJDK/openjdk-jdk8u/archive/';
-const JDK_BIN_VERSION = JDK_VERSION.replace('-', '');
-const JDK_FILE_NAME_MAC = `OpenJDK8U-jdk_x64_mac_hotspot_${JDK_BIN_VERSION}.tar.gz`;
-const JDK_FILE_NAME_WIN32 = `OpenJDK8U-jdk_x86-32_windows_hotspot_${JDK_BIN_VERSION}.zip`;
-const JDK_FILE_NAME_LINUX64 = `OpenJDK8U-jdk_x64_linux_hotspot_${JDK_BIN_VERSION}.tar.gz`;
-const JDK_SRC_ZIP = `jdk${JDK_VERSION}.zip`;
-const JDK_SOURCE_SIZE = 136130622;
+const JDK_VERSION = '11.0.1+13';
+const JDK_DIR = `jdk-${JDK_VERSION}`;
+const DOWNLOAD_JDK_BIN_ROOT = `https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VERSION}/`;
+const DOWNLOAD_JDK_SRC_ROOT = 'https://github.com/adoptium/jdk11u/archive/refs/tags/';
+const JDK_BIN_VERSION = JDK_VERSION.replace('+', '_');
+const JDK_FILE_NAME_MAC = `OpenJDK11U-jdk_x64_mac_hotspot_${JDK_BIN_VERSION}.tar.gz`;
+const JDK_FILE_NAME_WIN32 = `OpenJDK11U-jdk_x86-32_windows_hotspot_${JDK_BIN_VERSION}.zip`;
+const JDK_FILE_NAME_LINUX64 = `OpenJDK11U-jdk_x64_linux_hotspot_${JDK_BIN_VERSION}.tar.gz`;
+const JDK_SRC_ZIP = `jdk-${JDK_VERSION}.zip`;
+const JDK_SOURCE_SIZE = 190391098;
 
 /**
- * Install JDK 8 by downloading the binary and source code and
+ * Install JDK 11 by downloading the binary and source code and
  * decompressing it. Source code is required
  * based on discussions with legal team about licensing.
  */
@@ -73,7 +73,7 @@ export class JdkInstaller {
   }
 
   /**
-   * Downloads the platform-appropriate version of JDK 8, including
+   * Downloads the platform-appropriate version of JDK 11, including
    * binary and source code.
    *
    * @param installPath {string} path to install JDK at.

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -340,12 +340,12 @@ the PWA:
 
 \t\t- To open ${italic('https://example.com/')}: ${cyan('/')}
 \t\t- To open ${italic('https://example.com/path-to-pwa/')}: ${cyan('/path-to-pwa/')}\n`,
-  messageDownloadJdk: 'Downloading JDK 8 to ',
+  messageDownloadJdk: 'Downloading JDK 11 to ',
   messageDownloadSdk: 'Downloading Android SDK to ',
-  messageDownloadJdkSrc: 'Downloading the JDK 8 Sources...',
-  messageDecompressJdkSrc: 'Decompressing the JDK 8 Sources...',
-  messageDownloadJdkBin: 'Downloading the JDK 8 Binaries...',
-  messageDecompressJdkBin: 'Decompressing the JDK 8 Binaries...',
+  messageDownloadJdkSrc: 'Downloading the JDK 11 Sources...',
+  messageDecompressJdkSrc: 'Decompressing the JDK 11 Sources...',
+  messageDownloadJdkBin: 'Downloading the JDK 11 Binaries...',
+  messageDecompressJdkBin: 'Decompressing the JDK 11 Binaries...',
   messageDownloadAndroidSdk: 'Downloading the Android SDK...',
   messageDecompressAndroidSdk: 'Decompressing the Android SDK...',
   promptCreateDirectory: (directory: string): string => {
@@ -404,8 +404,8 @@ the PWA:
   jdkPathIsNotCorrect: 'The jdkPath isn\'t correct, please run the following command to update ' +
       'it:\nbubblewrap updateConfig --jdkPath <path-to-jdk>, such that the folder of the path' +
       'contains the file "release". Then run bubblewrap doctor again.',
-  jdkIsNotSupported: 'Unsupported jdk version. Please download "OpenJDK 8(LTS)" at the link ' +
-      'below:\nhttps://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=hotspot.',
+  jdkIsNotSupported: 'Unsupported jdk version. Please download "OpenJDK 11(LTS)" at the link ' +
+      'below:\nhttps://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=hotspot.',
   androidSdkPathIsNotCorrect: 'The androidSdkPath isn\'t correct, please run the following ' +
       'command to update it:\nbubblewrap updateConfig --androidSdkPath <path-to-sdk>, such that ' +
       'the folder of the path contains the folder "build". Then run bubblewrap doctor again.',


### PR DESCRIPTION
This updates the JDK used to match the JDK that is currently distributed
by Android Studio. This would help keep the building of Android apps
consistent between Android Studio and Bubblewrap. Additionally, this
unlocks the ability for bubblewrap to support keystores that utilize
aes encrypted keys.