### PR TITLE
Set a default user-agent

### DIFF
--- a/packages/core/src/lib/FetchUtils.ts
+++ b/packages/core/src/lib/FetchUtils.ts
@@ -15,13 +15,17 @@
  */
 
 import * as fs from 'fs';
-import {fetch as fetchh2, Response as FetchH2Response} from 'fetch-h2';
+import {context, Response as FetchH2Response} from 'fetch-h2';
 import nodefetch, {Response as NodeFetchResponse} from 'node-fetch';
 
 export type FetchEngine = 'node-fetch' | 'fetch-h2';
 const DEFAULT_FETCH_ENGINE: FetchEngine = 'fetch-h2';
 
 export type NodeFetchOrFetchH2Response = FetchH2Response | NodeFetchResponse;
+
+const userAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0';
+const fetchh2Ctx = context({userAgent:userAgent, overwriteUserAgent: true});
+const fetchh2 = fetchh2Ctx.fetch;
 
 class FetchUtils {
   private fetchEngine = DEFAULT_FETCH_ENGINE;

--- a/packages/core/src/lib/FetchUtils.ts
+++ b/packages/core/src/lib/FetchUtils.ts
@@ -24,7 +24,7 @@ const DEFAULT_FETCH_ENGINE: FetchEngine = 'fetch-h2';
 export type NodeFetchOrFetchH2Response = FetchH2Response | NodeFetchResponse;
 
 const userAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0';
-const fetchh2Ctx = context({userAgent:userAgent, overwriteUserAgent: true});
+const fetchh2Ctx = context({userAgent: userAgent, overwriteUserAgent: true});
 const fetchh2 = fetchh2Ctx.fetch;
 
 class FetchUtils {
@@ -36,7 +36,7 @@ class FetchUtils {
 
   async fetch(input: string): Promise<NodeFetchOrFetchH2Response> {
     if (this.fetchEngine == 'node-fetch') {
-      return await nodefetch(input, {redirect: 'follow'});
+      return await nodefetch(input, {redirect: 'follow', headers: {'User-Agent': userAgent}});
     } else {
       return await fetchh2(input, {redirect: 'follow'});
     }


### PR DESCRIPTION
This changes the user agent that is being sent to sites to match that of
a browser. Some sites were blocking our requests because of the default
user agent. node-fetch has some issues when attempting to set the user
agent, so this was left alone for now, especially because in #552 there
is a mention of potentially removing the user agent.