### PR TITLE
Fixes check for JDK version

### DIFF
--- a/packages/core/src/lib/jdk/JdkHelper.ts
+++ b/packages/core/src/lib/jdk/JdkHelper.ts
@@ -110,9 +110,9 @@ export class JdkHelper {
     try {
       const releaseFilePath = join(javaHome, 'release');
       const file = await fsPromises.readFile(releaseFilePath, 'utf-8');
-      if (file.indexOf('JAVA_VERSION="11.0.9.1') < 0) { // Checks if the jdk's version is 11 as needed
+      if (file.indexOf('JAVA_VERSION="11.0') < 0) { // Checks if the jdk's version is 11 as needed
         return Result.error(new ValidatePathError(
-            'JDK version not supported. JDK version 11.0.9.1 is required.', 'PathIsNotSupported'));
+            'JDK version not supported. JDK version 11 is required.', 'PathIsNotSupported'));
       }
     } catch (e) {
       return Result.error(new ValidatePathError(

--- a/packages/core/src/spec/lib/jdk/JdkHelperSpec.ts
+++ b/packages/core/src/spec/lib/jdk/JdkHelperSpec.ts
@@ -72,7 +72,7 @@ describe('JdkHelper', () => {
     it('Creates a Linux environment and checks that a valid path will pass', async () => {
       mock({
         'jdk': {
-          'release': 'JAVA_VERSION="1.8',
+          'release': 'JAVA_VERSION="11.0.1',
         }});
       expect((await JdkHelper.validatePath('jdk', LINUX_PROCESS)).isOk()).toBeTrue();
       mock.restore();
@@ -93,7 +93,7 @@ describe('JdkHelper', () => {
         'jdk': {
           'Contents': {
             'Home': {
-              'release': 'JAVA_VERSION="1.8"',
+              'release': 'JAVA_VERSION="11.0.1"',
             },
           },
         }});


### PR DESCRIPTION
- Updates validatePath() to check for the version, according to the
  `release` file.
- Fixes related test.