### PR TITLE
Escape gradle string in shareTarget / build.gradle

### DIFF
--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -306,13 +306,14 @@ describe('util', () => {
   });
 
   describe('#escapeJsonString combined with #escapeGradleString returns the expected results',
-   () => {
-    it ('Escapes double and single quotes', () => {
-      // String.raw prevents escape characters from being applied, so we can simplify howe we write
-      // the expected value.
-      let expected = String.raw`\\"Hello Worl\\\'d\\"`;
-      expect(util.escapeJsonString(util.escapeGradleString(`"Hello Worl'd"`)))
-          .toEqual(expected);
-    });
-  });
+      () => {
+        it('Escapes double and single quotes', () => {
+          // String.raw prevents escape characters from being applied, so we can simplify howe we write
+          // the expected value.
+          const input = String.raw`"Hello Worl'd"`;
+          const expected = String.raw`\\"Hello Worl\\\'d\\"`;
+          expect(util.escapeJsonString(util.escapeGradleString(input)))
+              .toEqual(expected);
+        });
+      });
 });

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -304,4 +304,14 @@ describe('util', () => {
           .toEqual('\\"\\$Hello\\\\Wo\\`eld\\"');
     });
   });
+
+  describe('#escapeJsonString combined with #escapeGradleString returns the expected results', () => {
+    it ('Escapes double and single quotes', () => {
+      // String.raw prevents escape characters from being applied, so we can simplify howe we write
+      // the expected value.
+      let expected = String.raw`\\"Hello Worl\\\'d\\"`;
+      expect(util.escapeJsonString(util.escapeGradleString(`"Hello Worl'd"`)))
+          .toEqual(expected);
+    });
+  });
 });

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -308,7 +308,7 @@ describe('util', () => {
   describe('#escapeJsonString combined with #escapeGradleString returns the expected results',
       () => {
         it('Escapes double and single quotes', () => {
-          // String.raw prevents escape characters from being applied, so we can simplify howe we write
+          // String.raw prevents escape characters from being applied, so we can simplify how we write
           // the expected value.
           const input = String.raw`"Hello Worl'd"`;
           const expected = String.raw`\\"Hello Worl\\\'d\\"`;

--- a/packages/core/src/spec/lib/utilSpec.ts
+++ b/packages/core/src/spec/lib/utilSpec.ts
@@ -305,7 +305,8 @@ describe('util', () => {
     });
   });
 
-  describe('#escapeJsonString combined with #escapeGradleString returns the expected results', () => {
+  describe('#escapeJsonString combined with #escapeGradleString returns the expected results',
+   () => {
     it ('Escapes double and single quotes', () => {
       // String.raw prevents escape characters from being applied, so we can simplify howe we write
       // the expected value.

--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -77,7 +77,7 @@ android {
 
         <% if (shareTarget) { %>
             // The data for the app to support web share target.
-            resValue "string", "shareTarget", '<%= escapeJsonString(JSON.stringify(shareTarget)) %>'
+            resValue "string", "shareTarget", '<%= escapeJsonString(escapeGradleString(JSON.stringify(shareTarget))) %>'
         <% } %>
 
         // The hostname is used when building the intent-filter, so the TWA is able to


### PR DESCRIPTION
Escapes the gradle string before escaping the JSON. This ensures single quotes
are escaped.

Fixes #673