### PR TITLE
feat: add docker image for cli

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,5 +38,6 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           [ "$VERSION" == "merge" ] && exit 0
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && docker tag $IMAGE_NAME $IMAGE_ID:latest && docker push $IMAGE_ID:latest
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,5 +37,6 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=next
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
+          [ "$VERSION" == "merge" ] && exit 0
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,12 +13,7 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker
+
+on:   
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+env:
+  IMAGE_NAME: bubblewrap
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "main" ] && VERSION=next
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:18-alpine
+FROM node:18-bullseye
 
 RUN npm install -g svg2img @bubblewrap/cli
 
-RUN apk add --update openjdk11-jdk
+RUN apt update && apt install -y openjdk-11-jre openjdk-11-jdk lib32stdc++6 lib32z1
 
 RUN mkdir -p /root/.bubblewrap && \
-  echo '{ "jdkPath": "/usr/lib/jvm/java-11-openjdk", "androidSdkPath": "" }' > /root/.bubblewrap/config.json
+  echo '{ "jdkPath": "/usr/lib/jvm/java-11-openjdk-amd64", "androidSdkPath": "" }' > /root/.bubblewrap/config.json
 
 RUN yes | bubblewrap doctor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+RUN npm install -g svg2img @bubblewrap/cli
+
+RUN apk add --update openjdk11-jdk
+
+RUN mkdir -p /root/.bubblewrap && \
+  echo '{ "jdkPath": "/usr/lib/jvm/java-11-openjdk", "androidSdkPath": "" }' > /root/.bubblewrap/config.json
+
+RUN yes | bubblewrap doctor
+
+WORKDIR /app
+
+ENTRYPOINT ["bubblewrap"]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,13 @@ When running Bubblewrap for the first time, it will offer to automatically downl
 external dependencies. This is the recommended setup, but it's possible to
 [manually setup the environment](#manually-setting-up-the-environment).
 
+## Container
+
+As an alternative to running the cli on your machine with Node.js directly you can use this 
+container image which got the cli and all dependencies pre-installed. To use the cli run
+`docker run --rm -ti ghcr.io/GoogleChromeLabs/bubblewrap:latest [cmd]` as you would normally 
+use `bubblewrap [cmd]`.
+
 ## Quickstart Guide
 
 ### Installing Bubblewrap


### PR DESCRIPTION
Add a docker image which ships the bubblewrap cli (with all needed dependencies like java & android-sdk). This docker image can be used to easily run the cli as container for local use or for example in CI systems.

To build the container image this PR introduces a new Github workflow pushing the container image to <https://ghcr.io>. The workflow will create a `:next` tagged image on pushes to the `main` branch and to git tags / releases it will push an image with the tag name without the `v` prefix.