### PR TITLE
Typo Fixes: Fix typos and hardcoding in comments of build.gradle config file

### DIFF
--- a/packages/core/template_project/app/build.gradle
+++ b/packages/core/template_project/app/build.gradle
@@ -42,7 +42,7 @@ def twaManifest = [
     // The duration of fade out animation in milliseconds to be played when removing splash screen.
     splashScreenFadeOutDuration: <%= splashScreenFadeOutDuration %>,
     generatorApp: '<%= generatorApp %>', // Application that generated the Android Project
-    // The fallback strategy for when Trusted Web Activity is not avilable. Possible values are
+    // The fallback strategy for when Trusted Web Activity is not available. Possible values are
     // 'customtabs' and 'webview'.
     fallbackType: '<%= fallbackType %>',
     enableSiteSettingsShortcut: '<%= enableSiteSettingsShortcut %>',
@@ -86,7 +86,7 @@ android {
         <% } %>
 
         // The hostname is used when building the intent-filter, so the TWA is able to
-        // handle Intents to open https://svgomg.firebaseapp.com.
+        // handle Intents to open host url of the application.
         resValue "string", "hostName", twaManifest.hostName
 
         // This attribute sets the status bar color for the TWA. It can be either set here or in
@@ -118,7 +118,7 @@ android {
         // Trusted Web Activity.
         resValue "color", "backgroundColor", twaManifest.backgroundColor
 
-        // Defines a provider authority fot the Splash Screen
+        // Defines a provider authority for the Splash Screen
         resValue "string", "providerAuthority", twaManifest.applicationId + '.fileprovider'
 
         // The enableNotification resource is used to enable or disable the


### PR DESCRIPTION
This PR intends to fix the following two things in the comments of the `build.gradle` file:

- The [demo app URL](https://svgomg.firebaseapp.com) is hardcoded at `hostName` part of the config.
- Two minor typos.