### PR TITLE
Show notification permission request prompt on Android T+

### DIFF
--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -97,7 +97,7 @@ export class FeatureManager {
     if (twaManifest.features.arCore?.enabled) {
       this.addFeature(new ArCoreFeature());
     }
-    
+
     // Android T+ needs permission to request sending notifications.
     if (twaManifest.enableNotifications) {
       this.androidManifest.permissions.add('android.permission.POST_NOTIFICATIONS');

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -97,6 +97,11 @@ export class FeatureManager {
     if (twaManifest.features.arCore?.enabled) {
       this.addFeature(new ArCoreFeature());
     }
+    
+    // Android T+ needs permission to request sending notifications.
+    if (twaManifest.enableNotifications) {
+      this.androidManifest.permissions.add('android.permission.POST_NOTIFICATIONS');
+    }
   }
 
   private addFeature(feature: Feature): void {

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -232,7 +232,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </service>
-                
+
         <% if (enableNotifications) { %>
             <activity android:name="com.google.androidbrowserhelper.trusted.NotificationPermissionRequestActivity" />
         <% } %>

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -232,6 +232,10 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </service>
+                
+        <% if (enableNotifications) { %>
+            <activity android:name="com.google.androidbrowserhelper.trusted.NotificationPermissionRequestActivity" />
+        <% } %>
 
         <% for(const component of androidManifest.components) { %>
             <%= component %>


### PR DESCRIPTION
This makes notifications work again on Android 13 (and newer) by declaring an activity for showing the notification permission request prompt.

Potentially fixes #730 