### PR TITLE
Update TwaManifest.ts shortcut comment

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -112,9 +112,9 @@ type alphaDependencies = {
  * enableSiteSettingsShortcut: true, // Set to false to disable the shortcut into site settings.
  * // Add shortcuts for your app here. Every shortcut must include the following fields:
  * // - name: String that will show up in the shortcut.
- * // - short_name: Shorter string used if |name| is too long.
+ * // - shortName: Shorter string used if |name| is too long.
  * // - url: Absolute path of the URL to launch the app with (e.g '/create').
- * // - icon: Name of the resource in the drawable folder to use as an icon.
+ * // - chosenIconUrl: Name of the resource in the drawable folder to use as an icon.
  * shortcuts: [
  *      // Insert shortcuts here, for example:
  *      // { name: 'Open SVG', shortName: 'Open', url: '/open', chosenIconUrl: 'https://example.com/example.svg' }

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -117,7 +117,7 @@ type alphaDependencies = {
  * // - icon: Name of the resource in the drawable folder to use as an icon.
  * shortcuts: [
  *      // Insert shortcuts here, for example:
- *      // [name: 'Open SVG', short_name: 'Open', url: '/open', icon: 'splash']
+ *      // { name: 'Open SVG', shortName: 'Open', url: '/open', chosenIconUrl: 'https://example.com/example.svg' }
  *  ],
  * // The duration of fade out animation in milliseconds to be played when removing splash screen.
  * splashScreenFadeOutDuration: 300


### PR DESCRIPTION
**Describe the issue**
The shortcuts attribute is not working and the comments on how to do this is also wrong.

```diff
 * shortcuts: [
 *      // Insert shortcuts here, for example:
- *      // [name: 'Open SVG', short_name: 'Open', url: '/open', icon: 'splash']
+ *      // { name: 'Open SVG', shortName: 'Open', url: '/open', chosenIconUrl: 'https://example.com/example.svg' }
 *  ],
```

1. The comment above should actually be an object rather than an array.
2. There should be `chosenIconUrl` according to the cli.
3. It should be `shortName` not `short_name` as it creates errors.


```
C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\util.js:299
    return input.replace(/[\\']/g, '\\\\\\$&');
                 ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.escapeGradleString (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\util.js:299:18)
    at ShortcutInfo.toString (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\ShortcutInfo.js:49:35)
    at C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaManifest.js:205:67
    at Array.map (<anonymous>)
    at Object.generateShortcuts (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaManifest.js:205:37)
    at eval (lodash.templateSources[0]:34:11)
    at TwaGenerator.applyTemplate (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaGenerator.js:179:55)

Node.js v18.13.0
```