### PR TITLE
Update DigitalAssetLinks.ts

### DIFF
--- a/packages/core/src/lib/DigitalAssetLinks.ts
+++ b/packages/core/src/lib/DigitalAssetLinks.ts
@@ -16,19 +16,17 @@
 
 export class DigitalAssetLinks {
   static generateAssetLinks(applicationId: string, ...sha256Fingerprints: string[]): string {
-    const assetlinks = new Array<string>();
-    assetlinks.push('[');
-    sha256Fingerprints.forEach((sha256Fingerprint, index) => {
-      if (index > 0) {
-        assetlinks.push(',');
+    if (sha256Fingerprints.length === 0) {
+      return '[]';
+    }
+
+    return `[{
+      "relation": ["delegate_permission/common.handle_all_urls"],
+      "target": {
+        "namespace": "android_app",
+        "package_name": "${applicationId}",
+        "sha256_cert_fingerprints": ["${sha256Fingerprints.join('\", \"')}"]
       }
-      assetlinks.push(`{
-        "relation": ["delegate_permission/common.handle_all_urls"],
-        "target" : { "namespace": "android_app", "package_name": "${applicationId}",
-                     "sha256_cert_fingerprints": ["${sha256Fingerprint}"] }
-      }\n`);
-    });
-    assetlinks.push(']');
-    return assetlinks.join('');
+    }]\n`;
   }
 }

--- a/packages/core/src/spec/lib/DigitalAssetLinksSpec.ts
+++ b/packages/core/src/spec/lib/DigitalAssetLinksSpec.ts
@@ -42,17 +42,13 @@ describe('DigitalAssetLinks', () => {
     it('Supports multiple fingerprints', () => {
       const digitalAssetLinks =
         JSON.parse(DigitalAssetLinks.generateAssetLinks(packageName, '123', '456'));
-      expect(digitalAssetLinks.length).toBe(2);
+      expect(digitalAssetLinks.length).toBe(1);
       expect(digitalAssetLinks[0].relation[0]).toBe('delegate_permission/common.handle_all_urls');
       expect(digitalAssetLinks[0].target.namespace).toBe('android_app');
       expect(digitalAssetLinks[0].target.package_name).toBe(packageName);
-      expect(digitalAssetLinks[0].target.sha256_cert_fingerprints.length).toBe(1);
+      expect(digitalAssetLinks[0].target.sha256_cert_fingerprints.length).toBe(2);
       expect(digitalAssetLinks[0].target.sha256_cert_fingerprints[0]).toBe('123');
-      expect(digitalAssetLinks[1].relation[0]).toBe('delegate_permission/common.handle_all_urls');
-      expect(digitalAssetLinks[1].target.namespace).toBe('android_app');
-      expect(digitalAssetLinks[1].target.package_name).toBe(packageName);
-      expect(digitalAssetLinks[1].target.sha256_cert_fingerprints.length).toBe(1);
-      expect(digitalAssetLinks[1].target.sha256_cert_fingerprints[0]).toBe('456');
+      expect(digitalAssetLinks[0].target.sha256_cert_fingerprints[1]).toBe('456');
     });
   });
 });


### PR DESCRIPTION
# Problem (?) I had before

After using bubblewrap for the first time, I had 1 issue that took me days to fix.
It was the Digital Asset Links JSON file.

The problem was the fingerprints were spread out on one item in arrays.

```json
[
  {
    "relation": [
      "delegate_permission/common.handle_all_urls"
    ],
    "target": {
      "namespace": "android_app",
      "package_name": "app.web.test.twa",
      "sha256_cert_fingerprints": ["fingerprint1"]
    }
  },
  {
    "relation": [
      "delegate_permission/common.handle_all_urls"
    ],
    "target": {
      "namespace": "android_app",
      "package_name": "app.web.test.twa",
      "sha256_cert_fingerprints": ["fingerprint2"]
    }
  }
]
```

This was how the file was generated.


# Fix
After looking at few sources, I came to conclusion that the `assetlinks.json` file should be something like below.

1. [Example Format in AssetLinks docs - Google](https://github.com/google/digitalassetlinks/blob/master/well-known/details.md#assetdescriptor)
2. [Example File in AssetLinks docs - Google](https://github.com/google/digitalassetlinks/blob/master/well-known/specification.md#details)
3. Also, looking at few examples such as [Google Docs AssetLinks.json](https://0.docs.google.com/.well-known/assetlinks.json), we can see that the fingerprints are contained in arrays by package names.
4. Checking out why my site was not validated in Google Play Console

> Note: I could not recreate the error message Google Play Console told me to update my `asssetlinks.json` file to contain all the fingerprints in one array. I will edit this pull request again if I manage to do so.

```json
[
  {
    "relation": [
      "delegate_permission/common.handle_all_urls"
    ],
    "target": {
      "namespace": "android_app",
      "package_name": "app.web.test.twa",
      "sha256_cert_fingerprints": [
        "fingerprint1",
        "fingerprint2"
      ]
    }
  }
]
```

# Todos
- [x] Update corresponding testing files
- [ ] Recreate Google Play Console Error Message