### PR TITLE
Update `short_name` and `shortName` key, type, test

### DIFF
--- a/packages/core/src/lib/ShortcutInfo.ts
+++ b/packages/core/src/lib/ShortcutInfo.ts
@@ -48,9 +48,9 @@ export class ShortcutInfo {
 
   toString(index: number): string {
     return `[name:'${escapeGradleString(this.name)}', ` +
-      `short_name:'${escapeGradleString(this.shortName)}', ` +
+      `shortName:'${escapeGradleString(this.shortName)}', ` +
       `url:'${this.url}', ` +
-      `icon:'${this.assetName(index)}']`;
+      `chosenIconUrl:'${this.assetName(index)}']`;
   }
 
   assetName(index: number): string {
@@ -66,7 +66,8 @@ export class ShortcutInfo {
    * @returns {TwaManifest}
    */
   static fromShortcutJson(webManifestUrl: URL, shortcut: WebManifestShortcutJson): ShortcutInfo {
-    const name = shortcut.name || shortcut.short_name;
+    const manifestShortName = shortcut.shortName || shortcut.short_name;
+    const name = shortcut.name || manifestShortName;
 
     if (!shortcut.icons || !shortcut.url || !name) {
       throw new Error('missing metadata');
@@ -88,7 +89,7 @@ export class ShortcutInfo {
       return icon ? new URL(icon.src, webManifestUrl).toString() : undefined;
     }
 
-    const shortName = shortcut.short_name || shortcut.name!.substring(0, SHORT_NAME_MAX_SIZE);
+    const shortName = manifestShortName || shortcut.name!.substring(0, SHORT_NAME_MAX_SIZE);
     const url = new URL(shortcut.url, webManifestUrl).toString();
     const shortcutInfo = new ShortcutInfo(name!, shortName!, url, resolveIconUrl(suitableIcon),
         resolveIconUrl(suitableMaskableIcon), resolveIconUrl(suitableMonochromeIcon));

--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -422,6 +422,7 @@ export class TwaManifest {
         TwaManifest.log.warn(`Skipping shortcut[${i}] for ${err}.`);
       }
       if (shortcuts.length === 4) {
+        TwaManifest.log.warn(`Skipping remaining ${webManifest.shortcuts!.length - 4} shortcuts.`);
         break;
       }
     }

--- a/packages/core/src/lib/types/WebManifest.ts
+++ b/packages/core/src/lib/types/WebManifest.ts
@@ -25,6 +25,7 @@ export interface WebManifestIcon {
 
 export interface WebManifestShortcutJson {
   name?: string;
+  shortName?: string;
   short_name?: string;
   url?: string;
   icons?: Array<WebManifestIcon>;

--- a/packages/core/src/spec/lib/ShortcutInfoSpec.ts
+++ b/packages/core/src/spec/lib/ShortcutInfoSpec.ts
@@ -21,8 +21,9 @@ describe('ShortcutInfo', () => {
     it('creates a correct TWA shortcut', () => {
       const shortcut = {
         'name': 'shortcut name',
-        'short_name': 'short',
+        'shortName': 'short',
         'url': '/launch',
+        'chosenIconUrl': '/shortcut_icon.png',
         'icons': [{
           'src': '/shortcut_icon.png',
           'sizes': '96x96',
@@ -32,12 +33,22 @@ describe('ShortcutInfo', () => {
       const shortcutInfo = ShortcutInfo.fromShortcutJson(manifestUrl, shortcut);
       expect(shortcutInfo.name).toBe('shortcut name');
       expect(shortcutInfo.shortName).toBe('short');
-      expect(shortcutInfo.url).toBe('https://pwa-directory.com/launch');
-      expect(shortcutInfo.chosenIconUrl)
-          .toBe('https://pwa-directory.com/shortcut_icon.png');
-      expect(shortcutInfo.toString(0))
-          .toBe('[name:\'shortcut name\', short_name:\'short\',' +
-            ' url:\'https://pwa-directory.com/launch\', icon:\'shortcut_0\']');
+    });
+
+    it('works with short_name, too', () => {
+      const shortcut = {
+        'name': 'shortcut name',
+        'short_name': 'short',
+        'url': '/launch',
+        'chosenIconUrl': '/shortcut_icon.png',
+        'icons': [{
+          'src': '/shortcut_icon.png',
+          'sizes': '96x96',
+        }],
+      };
+      const manifestUrl = new URL('https://pwa-directory.com/manifest.json');
+      const shortcutInfo = ShortcutInfo.fromShortcutJson(manifestUrl, shortcut);
+      expect(shortcutInfo.shortName).toBe('short');
     });
 
     it('Throws if icon size is empty or too small', () => {

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -41,8 +41,9 @@ describe('TwaManifest', () => {
         'background_color': '#7cc0ff',
         'shortcuts': [{
           'name': 'shortcut name',
-          'short_name': 'short',
+          'shortName': 'short',
           'url': '/launch',
+          'chosenIconUrl': '/shortcut_icon.png',
           'icons': [{
             'src': '/shortcut_icon.png',
             'sizes': '96x96',
@@ -81,8 +82,8 @@ describe('TwaManifest', () => {
       expect(twaManifest.shortcuts[0].chosenIconUrl)
           .toBe('https://pwa-directory.com/shortcut_icon.png');
       expect(twaManifest.generateShortcuts())
-          .toBe('[[name:\'shortcut name\', short_name:\'short\',' +
-            ' url:\'https://pwa-directory.com/launch\', icon:\'shortcut_0\']]');
+          .toBe('[[name:\'shortcut name\', shortName:\'short\',' +
+            ' url:\'https://pwa-directory.com/launch\', chosenIconUrl:\'shortcut_0\']]');
       expect(twaManifest.fallbackType).toBe('customtabs');
     });
 
@@ -119,7 +120,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.retainedBundles).toEqual([]);
     });
 
-    it('Uses "name" when "short_name" is not available', () => {
+    it('Uses "name" when "shortName" is not available', () => {
       const manifest = {
         'name': 'PWA Directory',
       };
@@ -350,8 +351,7 @@ describe('TwaManifest', () => {
           'src': 'https://image.png',
           'sizes': '512x512',
           'purpose': 'any',
-        },
-        ],
+        }],
       };
       const twaManifest = new TwaManifest({
         'packageId': 'id',
@@ -410,8 +410,7 @@ describe('TwaManifest', () => {
           'src': 'https://image.png',
           'sizes': '512x512',
           'purpose': 'any',
-        },
-        ],
+        }],
       };
       const twaManifest = new TwaManifest({
         'packageId': 'id',


### PR DESCRIPTION
# Opinion
Assuming that [Example in Test File](https://github.com/GoogleChromeLabs/bubblewrap/blob/81adecf07002fbd55451558257bb86242d96066a/packages/core/src/spec/lib/TwaManifestSpec.ts#L219) is the most basic object to create shortcuts, there are a lot of codes/test/types (maybe) not updated.

But if `shortName` is the correct way to make short names rather than `short_name`, if the manifest is first fetched through the cli, it will create the following error as `shortName` doesn't exist.

```
C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\util.js:299
    return input.replace(/[\\']/g, '\\\\\\$&');
                 ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.escapeGradleString (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\util.js:299:18)
    at ShortcutInfo.toString (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\ShortcutInfo.js:49:35)
    at C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaManifest.js:205:67
    at Array.map (<anonymous>)
    at Object.generateShortcuts (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaManifest.js:205:37)
    at eval (lodash.templateSources[2]:34:11)
    at TwaGenerator.applyTemplate (C:\Users\USER\AppData\Roaming\npm\node_modules\@bubblewrap\cli\node_modules\@bubblewrap\core\dist\lib\TwaGenerator.js:179:55)

Node.js v18.13.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

So, I think the best approach is to make both handlers for `shortName` and `short_name` rather than using `shortName` only.

But then, some few tests and types files have either `shortName` or `short_name` which is really confusing while trying to understand how shortcuts work.

In conclusion, I think the best approach is to make `shortName` the default key for all, but make it possible to using `short_name`.

# Files Changed
`packages/core/src/lib/ShortcutInfo.ts`: Update the `.toString()` method, use both `short_name` and `shortName`.

`packages/core/src/lib/TwaManifest.ts`: Add warning message for skipping shortcuts items after 4.

`packages/core/src/lib/types/WebManifest.ts`: Add `short_name` type.

`packages/core/src/spec/lib/TwaManifestSpec.ts` & `packages/core/src/spec/lib/ShortcutInfoSpec.ts`: Update shortcut tests (+ Format icon key).