### PR TITLE
docs: lowercase registry url for docker

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,7 @@ external dependencies. This is the recommended setup, but it's possible to
 
 As an alternative to running the cli on your machine with Node.js directly you can use this 
 container image which got the cli and all dependencies pre-installed. To use the cli run
-`docker run --rm -ti ghcr.io/GoogleChromeLabs/bubblewrap:latest [cmd]` as you would normally 
+`docker run --rm -ti ghcr.io/googlechromelabs/bubblewrap:latest [cmd]` as you would normally 
 use `bubblewrap [cmd]`.
 
 ## Quickstart Guide


### PR DESCRIPTION
```
➜  docker run --rm -ti ghcr.io/GoogleChromeLabs/bubblewrap:latest build --config manifest.json 
docker: invalid reference format: repository name must be lowercase.
```

Not sure when this limitation came out.