### PR TITLE
Bump android-browser-helper billing library

### DIFF
--- a/packages/core/src/lib/features/PlayBillingFeature.ts
+++ b/packages/core/src/lib/features/PlayBillingFeature.ts
@@ -24,7 +24,7 @@ export class PlayBillingFeature extends EmptyFeature {
   constructor() {
     super('playbilling');
 
-    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.0.0-alpha10');
+    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.0.0-alpha11');
 
     this.androidManifest.components.push(`
         <activity


### PR DESCRIPTION
Bump android-browser-helper billing library to 1.0.0-alpha11, which is updated to Play Billing v6