### PR TITLE
Bump cli dependencies in package.json and update package-lock.json files

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bubblewrap/cli",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bubblewrap/cli",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/cli-progress": "^3.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@bubblewrap/core": "^1.21.0",
+    "@bubblewrap/core": "^1.22.0",
     "@bubblewrap/validator": "^1.20.0",
     "@types/cli-progress": "^3.7.0",
     "@types/color": "^3.0.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bubblewrap/core",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bubblewrap/core",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.2.0",


### PR DESCRIPTION
1. Fixes cli's dependency to core version 1.22.0
2. Updates versions to 1.22.0 in package-lock.json files