### PR TITLE
Fix `spawn EINVAL` error on windows

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -51,7 +51,7 @@ export async function execute(
   if (log) {
     log.debug(`Executing shell: ${joinedCmd}`);
   }
-  return await execPromise(joinedCmd, {env: env});
+  return await execPromise(joinedCmd, {env: env, shell: true});
 }
 
 export async function executeFile(
@@ -60,7 +60,7 @@ export async function executeFile(
   if (log) {
     log.debug(`Executing command ${cmd} with args ${args}`);
   }
-  return await execFilePromise(cmd, args, {env: env, cwd: cwd});
+  return await execFilePromise(cmd, args, {env: env, cwd: cwd, shell: true});
 }
 
 export async function unzipFile(


### PR DESCRIPTION
Fix #853 

This PR fixes a node.js breaking security batch for windows devices https://github.com/nodejs/node/issues/52554 when runnint `bubblewrap build`

The original error was 
```
>> bubblewrap build
,-----.        ,--.  ,--.  ,--.
|  |) /_,--.,--|  |-.|  |-.|  |,---.,--.   ,--,--.--.,--,--.,---.
|  .-.  |  ||  | .-. | .-. |  | .-. |  |.'.|  |  .--' ,-.  | .-. |
|  '--' '  ''  | `-' | `-' |  \   --|   .'.   |  |  \ '-'  | '-' '
`------' `----' `---' `---'`--'`----'--'   '--`--'   `--`--|  |-'
                                                           `--'    
Please, enter passwords for the keystore A:\projects\55-sanaye\pwa\android\android.keystore and alias android.

? Password for the Key Store: ********
? Password for the Key: ********
? Password for the Key: ********

Building the Android App...


cli ERROR spawn EINVAL
```

I patched the logger to log the trace:
```
Building the Android App...

cli ERROR spawn EINVAL

cli Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at spawn (node:child_process:760:9)
    at execFile (node:child_process:350:17)
    at node:child_process:242:21
    at executeFile (C:\Users\A7med\AppData\Local\pnpm\global\5\.pnpm\@bubblewrap+core@1.22.0_encoding@0.1.13\node_modules\@bubblewrap\core\dist\lib\util.js:68:18)
    at GradleWrapper.executeGradleCommand (C:\Users\A7med\AppData\Local\pnpm\global\5\.pnpm\@bubblewrap+core@1.22.0_encoding@0.1.13\node_modules\@bubblewrap\core\dist\lib\GradleWrapper.js:59:38)
    at GradleWrapper.assembleRelease (C:\Users\A7med\AppData\Local\pnpm\global\5\.pnpm\@bubblewrap+core@1.22.0_encoding@0.1.13\node_modules\@bubblewrap\core\dist\lib\GradleWrapper.js:51:20)
    at Build.buildApk (C:\Users\A7med\AppData\Local\pnpm\global\5\.pnpm\@bubblewrap+cli@1.22.0_encoding@0.1.13\node_modules\@bubblewrap\cli\dist\lib\cmds\build.js:108:34)
    at Build.build (C:\Users\A7med\AppData\Local\pnpm\global\5\.pnpm\@bubblewrap+cli@1.22.0_encoding@0.1.13\node_modules\@bubblewrap\cli\dist\lib\cmds\build.js:171:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## How this was tested?

I patched the dist to pass `shell: true` as proposed on https://github.com/nodejs/node/issues/52554 and it worked as expected