### PR TITLE
Fix #883 Add pathPrefix=scope to Android intent filter

### DIFF
--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -191,7 +191,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https"
-                    android:host="@string/hostName"/>
+                    android:host="@string/hostName"
+                <% if (fullScopeUrl && fullScopeUrl.pathname !== '/') { %>
+                    android:pathPrefix="<%= fullScopeUrl.pathname %>"
+                <% } %>
+                />
             </intent-filter>
 
             <% for (const additionalOrigin of additionalTrustedOrigins) { %>


### PR DESCRIPTION
Add pathPrefix to Android intent filter when "scope" is non-trivial.