### PR TITLE
Partial rollback of PR #881: exec() cannot have shell:true

### DIFF
--- a/packages/core/src/lib/util.ts
+++ b/packages/core/src/lib/util.ts
@@ -51,7 +51,7 @@ export async function execute(
   if (log) {
     log.debug(`Executing shell: ${joinedCmd}`);
   }
-  return await execPromise(joinedCmd, {env: env, shell: true});
+  return await execPromise(joinedCmd, {env: env});
 }
 
 export async function executeFile(


### PR DESCRIPTION
The original description mentioned the problem with `execFile()`, but the PR #881 updated both `exec()` and `execFile()`, where the `exec()` change was incorrect (see the [documentation](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback)), rolling it back.