### PR TITLE
Support minimal-ui display mode

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -39,7 +39,7 @@ const SHORT_NAME_MAX_SIZE = 12;
 const MIN_NOTIFICATION_ICON_SIZE = 48;
 
 // Supported display modes for TWA
-const DISPLAY_MODE_VALUES = ['standalone', 'fullscreen', 'fullscreen-sticky'];
+const DISPLAY_MODE_VALUES = ['standalone', 'minimal-ui', 'fullscreen', 'fullscreen-sticky'];
 export type DisplayMode = typeof DISPLAY_MODE_VALUES[number];
 export const DisplayModes: DisplayMode[] = [...DISPLAY_MODE_VALUES];
 

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -186,8 +186,6 @@ describe('TwaManifest', () => {
 
     it('Replaces unsupported display modes with `standalone`', () => {
       const manifestUrl = new URL('https://pwa-directory.com/manifest.json');
-      expect(TwaManifest.fromWebManifestJson(manifestUrl, {display: 'minimal-ui'}).display)
-          .toBe('standalone');
       expect(TwaManifest.fromWebManifestJson(manifestUrl, {display: 'browser'}).display)
           .toBe('standalone');
     });
@@ -333,11 +331,11 @@ describe('TwaManifest', () => {
     it('Returns display mode if it is supported', () => {
       expect(asDisplayMode('standalone')).toBe('standalone');
       expect(asDisplayMode('fullscreen')).toBe('fullscreen');
+      expect(asDisplayMode('minimal-ui')).toBe('minimal-ui');
     });
 
     it('Returns null for unsupported display modes', () => {
       expect(asDisplayMode('browser')).toBeNull();
-      expect(asDisplayMode('minimal-ui')).toBeNull();
       expect(asDisplayMode('bogus')).toBeNull();
       expect(asDisplayMode('')).toBeNull();
     });


### PR DESCRIPTION
Adds minimal-ui parsing support from web-manifest instead of returnign standalone.