### PR TITLE
Update getJavaHome on JdkHelper.ts

### DIFF
--- a/packages/core/src/lib/jdk/JdkHelper.ts
+++ b/packages/core/src/lib/jdk/JdkHelper.ts
@@ -78,13 +78,17 @@ export class JdkHelper {
    * @param {Config} config The bubblewrap general configuration
    * @param {NodeJS.Process} process Information from the OS process
    */
-  static getJavaHome(jdkPath: string, process: NodeJS.Process): string {
+  static getJavaHome(jdkPath, process) {
     const joinPath = (process.platform === 'win32') ? path.win32.join : path.posix.join;
-    if (process.platform === 'darwin') {
-      return joinPath(jdkPath, '/Contents/Home/');
-    } else if (process.platform === 'linux' || process.platform === 'win32') {
-      return joinPath(jdkPath, '/');
-    }
+      if (process.platform === 'darwin') {
+        // If jdkPath already ends with '/Contents/Home' (with or without a trailing slash), return as is.
+        if (jdkPath.endsWith('/Contents/Home') || jdkPath.endsWith('/Contents/Home/')) {
+          return jdkPath;
+        }
+          return joinPath(jdkPath, '/Contents/Home/');
+        } else if (process.platform === 'linux' || process.platform === 'win32') {
+          return joinPath(jdkPath, '/');
+      }
     throw new Error(`Unsupported Platform: ${process.platform}`);
   }
 


### PR DESCRIPTION
Update support for darwin by checking path and not duplicating /Contents/Home