### PR TITLE
Billing library bumped to 1.1.0, removed warnings about alpha dependencies

### DIFF
--- a/packages/cli/src/lib/cmds/init.ts
+++ b/packages/cli/src/lib/cmds/init.ts
@@ -139,10 +139,6 @@ async function confirmTwaConfig(twaManifest: TwaManifest, prompt: Prompt): Promi
 
   const playBillingEnabled = await prompt.promptConfirm(messages.promptPlayBilling, false);
   if (playBillingEnabled) {
-    twaManifest.alphaDependencies = {
-      enabled: true,
-    };
-
     twaManifest.features = {
       ...twaManifest.features,
       playBilling: {

--- a/packages/cli/src/lib/cmds/shared.ts
+++ b/packages/cli/src/lib/cmds/shared.ts
@@ -128,11 +128,6 @@ export async function updateProject(
     prompt.printMessage(messages.errorPlayBillingEnableNotifications);
     return false;
   }
-  // Check that if Play Billing is enabled, alphaDependencies must also be enabled.
-  if (features.playBilling?.enabled && !twaManifest.alphaDependencies.enabled) {
-    prompt.printMessage(messages.errorPlayBillingAlphaDependencies);
-    return false;
-  }
 
   // Check that the iconUrl exists.
   if (!twaManifest.iconUrl) {

--- a/packages/cli/src/lib/strings.ts
+++ b/packages/cli/src/lib/strings.ts
@@ -24,7 +24,6 @@ type Messages = {
   errorFailedToRunQualityCriteria: string;
   errorIconUrlMustExist: (manifest: string) => string;
   errorPlayBillingEnableNotifications: string;
-  errorPlayBillingAlphaDependencies: string;
   errorMaxLength: (maxLength: number, actualLength: number) => string;
   errorMinLength: (minLength: number, actualLength: number) => string;
   errorMissingManifestParameter: string;
@@ -149,8 +148,6 @@ export const enUS: Messages = {
       yellow('\nFailed to run the PWA Quality Criteria checks. Skipping.'),
   errorPlayBillingEnableNotifications: red(`Play Billing requires ${cyan('enableNotifications')} ` +
       `to be ${cyan('true')}.`),
-  errorPlayBillingAlphaDependencies: red(`Play Billing requires ${cyan('alphaDependencies')} ` +
-      'to be enabled.'),
   errorMaxLength: (maxLength, actualLength): string => {
     return `Maximum length is ${maxLength} but input is ${actualLength}.`;
   },
@@ -370,7 +367,7 @@ the PWA:
   promptMaskableIconUrl: 'Maskable icon URL:',
   promptMonochromeIconUrl: 'Monochrome icon URL:',
   promptShortcuts: 'Include app shortcuts?',
-  promptPlayBilling: 'Include support for Play Billing (this relies on alpha dependencies)?',
+  promptPlayBilling: 'Include support for Play Billing?',
   promptLocationDelegation: 'Request geolocation permission?',
   promptPackageId: 'Application ID:',
   promptKeyPath: 'Key store location:',

--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -71,12 +71,7 @@ export class FeatureManager {
     }
 
     if (twaManifest.features.playBilling?.enabled) {
-      if (twaManifest.alphaDependencies?.enabled) {
-        this.addFeature(new PlayBillingFeature());
-      } else {
-        log.error('Skipping PlayBillingFeature. '+
-            'Enable alphaDependencies to add PlayBillingFeature.');
-      }
+      this.addFeature(new PlayBillingFeature());
     }
 
     if (twaManifest.features.appsFlyer?.enabled) {

--- a/packages/core/src/lib/features/PlayBillingFeature.ts
+++ b/packages/core/src/lib/features/PlayBillingFeature.ts
@@ -24,7 +24,7 @@ export class PlayBillingFeature extends EmptyFeature {
   constructor() {
     super('playbilling');
 
-    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.0.1');
+    this.buildGradle.dependencies.push('com.google.androidbrowserhelper:billing:1.1.0');
 
     this.androidManifest.components.push(`
         <activity

--- a/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
+++ b/packages/core/src/spec/lib/features/FeatureManagerSpec.ts
@@ -178,9 +178,6 @@ describe('FeatureManager', () => {
             enabled: true,
           },
         },
-        alphaDependencies: {
-          enabled: true,
-        },
       } as TwaManifest;
 
       const playBillingFeature = new PlayBillingFeature();


### PR DESCRIPTION
Billing 1.1.0 in android-browser-helper includes support for Google Play Billing Client v7.1.1