### PR TITLE
Add display override to TWA manifest

### DIFF
--- a/packages/core/src/lib/TwaManifest.ts
+++ b/packages/core/src/lib/TwaManifest.ts
@@ -46,6 +46,11 @@ const DISPLAY_MODE_VALUES = ['standalone', 'minimal-ui', 'fullscreen', 'fullscre
 export type DisplayMode = typeof DISPLAY_MODE_VALUES[number];
 export const DisplayModes: DisplayMode[] = [...DISPLAY_MODE_VALUES];
 
+// Supported display overrides for TWA
+const DISPLAY_OVERRIDE_VALUES = ['window-controls-overlay'] as const;
+export type DisplayOverrideValue = typeof DISPLAY_OVERRIDE_VALUES[number];
+export const DisplayOverrideValues: DisplayOverrideValue[] = [...DISPLAY_OVERRIDE_VALUES];
+
 export function asDisplayMode(input: string): DisplayMode | null {
   return DISPLAY_MODE_VALUES.includes(input) ? input as DisplayMode : null;
 }
@@ -139,6 +144,7 @@ export class TwaManifest {
   name: string;
   launcherName: string;
   display: DisplayMode;
+  displayOverride: DisplayOverrideValue[];
   themeColor: Color;
   themeColorDark: Color;
   navigationColor: Color;
@@ -228,6 +234,10 @@ export class TwaManifest {
     this.protocolHandlers = data.protocolHandlers;
     this.fileHandlers = data.fileHandlers;
     this.launchHandlerClientMode = data.launchHandlerClientMode;
+    this.displayOverride = (data.displayOverride || []).filter(
+        (dio: string): dio is DisplayOverrideValue => {
+          return (DisplayOverrideValues as string[]).includes(dio);
+        });
   }
 
   /**
@@ -571,6 +581,7 @@ export interface TwaManifestJson {
   name: string;
   launcherName?: string; // Older Manifests may not have this field.
   display?: string; // Older Manifests may not have this field.
+  displayOverride?: string[];
   themeColor: string;
   themeColorDark?: string;
   navigationColor: string;

--- a/packages/core/src/lib/types/WebManifest.ts
+++ b/packages/core/src/lib/types/WebManifest.ts
@@ -35,6 +35,9 @@ export interface WebManifestShortcutJson {
 
 type WebManifestDisplayMode = 'browser' | 'minimal-ui' | 'standalone' | 'fullscreen';
 
+export type WebManifestDisplayOverrideValue = 'window-controls-overlay' | 'tabbed' | 'browser' |
+    'minimal-ui' | 'standalone' | 'fullscreen';
+
 export type OrientationLock = 'any' | 'natural' | 'landscape'| 'portrait' | 'portrait-primary'|
     'portrait-secondary' | 'landscape-primary' | 'landscape-secondary';
 
@@ -64,6 +67,7 @@ export interface WebManifestJson {
   start_url?: string;
   scope?: string;
   display?: WebManifestDisplayMode;
+  display_override?: WebManifestDisplayOverrideValue[];
   theme_color?: string;
   background_color?: string;
   icons?: Array<WebManifestIcon>;

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -14,7 +14,12 @@
  *  limitations under the License.
  */
 
-import {TwaManifest, TwaManifestJson, asDisplayMode} from '../../lib/TwaManifest';
+import {
+  TwaManifest,
+  TwaManifestJson,
+  asDisplayMode,
+  resolveDisplayOverride,
+} from '../../lib/TwaManifest';
 import {WebManifestJson} from '../../lib/types/WebManifest';
 import Color = require('color');
 import {ShortcutInfo} from '../../lib/ShortcutInfo';
@@ -208,7 +213,7 @@ describe('TwaManifest', () => {
         startUrl: '/',
         iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
         display: 'fullscreen',
-        displayOverride: ['window-controls-overlay', 'not-valid'],
+        displayOverride: ['window-controls-overlay'],
         orientation: 'landscape',
         themeColor: '#00ff00',
         themeColorDark: '#000000',
@@ -349,6 +354,39 @@ describe('TwaManifest', () => {
       expect(asDisplayMode('')).toBeNull();
     });
   });
+
+  describe('#resolveDisplayOverride', () => {
+    it('Keeps display override values that are supported', () => {
+      expect(resolveDisplayOverride([
+        'browser',
+        'fullscreen',
+        'minimal-ui',
+        'standalone',
+        'window-controls-overlay',
+        'tabbed',
+      ])).toEqual([
+        'browser',
+        'fullscreen',
+        'minimal-ui',
+        'standalone',
+        'window-controls-overlay',
+        'tabbed',
+      ]);
+    });
+
+    it('Ignore unsupported values', () => {
+      expect(resolveDisplayOverride([
+        'browser',
+        // @ts-expect-error Unsupported value for testing
+        'not-supported',
+      ])).toEqual(['browser']);
+      expect(resolveDisplayOverride([
+        // @ts-expect-error Unsupported value for testing
+        'not-supported',
+      ])).toEqual([]);
+    });
+  });
+
   describe('#merge', () => {
     it('Validates that the merge is done correctly in case which' +
         ' there are no fields to ignore', async () => {
@@ -382,6 +420,7 @@ describe('TwaManifest', () => {
         'name': 'name',
         'launcherName': 'name',
         'display': 'standalone',
+        'displayOverride': ['window-controls-overlay'],
         'themeColor': '#FFFFFF',
         'themeColorDark': '#000000',
         'navigationColor': '#000000',
@@ -427,6 +466,7 @@ describe('TwaManifest', () => {
         ...twaManifest.toJson(),
         'launcherName': 'different_name',
         'display': 'fullscreen',
+        'displayOverride': [],
         'protocolHandlers': [
           {
             'protocol': 'web+test-replace',

--- a/packages/core/src/spec/lib/TwaManifestSpec.ts
+++ b/packages/core/src/spec/lib/TwaManifestSpec.ts
@@ -208,6 +208,7 @@ describe('TwaManifest', () => {
         startUrl: '/',
         iconUrl: 'https://pwa-directory.com/favicons/android-chrome-512x512.png',
         display: 'fullscreen',
+        displayOverride: ['window-controls-overlay', 'not-valid'],
         orientation: 'landscape',
         themeColor: '#00ff00',
         themeColorDark: '#000000',
@@ -243,6 +244,7 @@ describe('TwaManifest', () => {
       expect(twaManifest.startUrl).toEqual(twaManifest.startUrl);
       expect(twaManifest.iconUrl).toEqual(twaManifest.iconUrl);
       expect(twaManifest.display).toEqual('fullscreen');
+      expect(twaManifest.displayOverride).toEqual(['window-controls-overlay']);
       expect(twaManifest.orientation).toEqual('landscape');
       expect(twaManifest.themeColor).toEqual(new Color('#00ff00'));
       expect(twaManifest.themeColorDark).toEqual(new Color('#000000'));

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -181,6 +181,12 @@
                     android:resource="@array/additional_trusted_origins" />
             <% } %>
 
+            <% if (displayOverride.length > 0) { %>
+                <meta-data
+                    android:name="android.support.customtabs.trusted.DISPLAY_OVERRIDE"
+                    android:resource="@array/display_override" />
+            <% } %>
+
             <% if (shareTargetIntentFilter) { %>
                 <intent-filter>
                     <% for (const action of shareTargetIntentFilter.actions) { %>

--- a/packages/core/template_project/app/src/main/res/values/strings.xml
+++ b/packages/core/template_project/app/src/main/res/values/strings.xml
@@ -23,6 +23,14 @@
     </string-array>
   <% } %>
 
+  <% if (displayOverride.length > 0) { %>
+    <string-array name="display_override">
+    <% for (const displayOverrideValue of displayOverride) { %>
+      <item><%= displayOverrideValue %></item>
+    <% } %>
+    </string-array>
+  <% } %>
+
   <!--
     This variable below expresses the relationship between the app and the site,
     as documented in the TWA documentation at


### PR DESCRIPTION
This handles the `display_override` web manifest fields and adds support for `window-controls-overlay` and `tabbed` display modes.

🔒 b/433357939