### PR TITLE
Add application_preferences to ManageDataLauncherActivity

### DIFF
--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -91,10 +91,16 @@
         <% } %>
 
         <% if (enableSiteSettingsShortcut) { %>
-            <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity">
-            <meta-data
-                android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"
-                android:value="@string/launchUrl" />
+            <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity"
+                android:exported="false"
+                android:excludeFromRecents="true">
+                <meta-data
+                    android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"
+                    android:value="@string/launchUrl" />
+                <intent-filter>
+                    <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
+                    <category android:name="android.intent.category.DEFAULT" />
+                </intent-filter>
             </activity>
         <% } %>
 

--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -93,6 +93,7 @@
         <% if (enableSiteSettingsShortcut) { %>
             <activity android:name="com.google.androidbrowserhelper.trusted.ManageDataLauncherActivity"
                 android:exported="false"
+                android:enabled="true"
                 android:excludeFromRecents="true">
                 <meta-data
                     android:name="android.support.customtabs.trusted.MANAGE_SPACE_URL"


### PR DESCRIPTION
Adds APPLICATION_PREFERENCES to ManageDataLauncherActivity

This allows for Site settings to appear in App info's "Additional settings in the app"

https://screencast.googleplex.com/cast/NTkxMTczNDg5NTI0NzM2MHw3MWJiMzVjOS1mMw

[b/424812276](b/424812276)