### PR TITLE
Bump android browser helper alpha to 2.7.0-alpha01

### DIFF
--- a/packages/core/src/lib/features/FeatureManager.ts
+++ b/packages/core/src/lib/features/FeatureManager.ts
@@ -27,7 +27,7 @@ import {FileHandlingFeature} from './FileHandlingFeature';
 
 const ANDROID_BROWSER_HELPER_VERSIONS = {
   stable: 'com.google.androidbrowserhelper:androidbrowserhelper:2.6.2',
-  alpha: 'com.google.androidbrowserhelper:androidbrowserhelper:2.6.2',
+  alpha: 'com.google.androidbrowserhelper:androidbrowserhelper:2.7.0-alpha01',
 };
 
 /**


### PR DESCRIPTION
At the time of writing this PR, 2.7.0-alpha01 may not be published to maven.

cc @gstepniewski-google 