### PR TITLE
fix(cli): use single quote to prevent bash expansion

### DIFF
--- a/packages/cli/src/lib/cmds/build.ts
+++ b/packages/cli/src/lib/cmds/build.ts
@@ -100,6 +100,10 @@ class Build {
     };
   }
 
+  formatPassword(password: string): string {
+    return `'${password}'`.replace(/'/g, "'\\''");
+  }
+
   async buildApk(): Promise<void> {
     await this.gradleWrapper.assembleRelease();
     await this.androidSdkTools.zipalignOnlyVerification(
@@ -111,9 +115,9 @@ class Build {
   async signApk(signingKey: SigningKeyInfo, passwords: SigningKeyPasswords): Promise<void> {
     await this.androidSdkTools.apksigner(
         signingKey.path,
-        `'${passwords.keystorePassword}'`,
+        this.formatPassword(passwords.keystorePassword),
         signingKey.alias,
-        `'${passwords.keyPassword}'`,
+        this.formatPassword(passwords.keyPassword),
         APK_ALIGNED_FILE_NAME, // input file path
         APK_SIGNED_FILE_NAME,
     );
@@ -126,8 +130,8 @@ class Build {
   async signAppBundle(signingKey: SigningKeyInfo, passwords: SigningKeyPasswords): Promise<void> {
     await this.jarSigner.sign(
         signingKey,
-        `'${passwords.keystorePassword}~'`,
-        `'${passwords.keyPassword}'`,
+        this.formatPassword(passwords.keystorePassword),
+        this.formatPassword(passwords.keyPassword),
         APP_BUNDLE_BUILD_OUTPUT_FILE_NAME,
         APP_BUNDLE_SIGNED_FILE_NAME);
   }


### PR DESCRIPTION
Fixes #973

### Problem

When signing APKs or App Bundles, the keystore password and key password are passed to command-line tools (apksigner and jarsigner). Currently, these passwords were wrapped in double quotes ("), which allows bash to perform expansion on special characters like $, !, backticks, and others.

For example, if a user's keystore password contains characters like `$ecret` or `pa$$word`, bash would interpret `$ecret` or `$$` as variable references, causing the signing process to fail with incorrect password errors.

### Solution
Updated `signApk()` and `signAppBundle()` methods to use single quotes instead of double quotes for password parameters, so we use the password as a literal string. Also escapes single quotes in the password.

### Testing
- Tested with passwords containing special characters ($, !, backticks)
- Verified APK and App Bundle signing still works with normal passwords