### PR TITLE
fix: enhance Android SDK detection and cross-platform PATH handling

### DIFF
--- a/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
+++ b/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
@@ -80,21 +80,23 @@ export class AndroidSdkTools {
     // those are not properly handled by the Android SDK, so we try running without wrapping the
     // value.
     // TODO(andreban): Check for spaces in the path and throw an Error if one is found.
-    let sdkRootEscapeChar = '"';
-    let sdkManagerPath = this.pathJoin(this.getAndroidHome(), '/tools/bin/sdkmanager');
-    if (this.process.platform === 'win32') {
-      sdkRootEscapeChar = '';
-      sdkManagerPath += '.bat';
+    const sdkRootEscapeChar = this.process.platform === 'win32' ? '' : '"';
+    const sdkManagerPathSuffix = this.process.platform === 'win32' ? '.bat' : '';
+    let sdkManagerPath: string | undefined;
+    const sdkManagerRelativePaths = [
+      'cmdline-tools/latest/bin/sdkmanager',
+      'tools/bin/sdkmanager',
+      'bin/sdkmanager',
+    ];
+    for (const relativePath of sdkManagerRelativePaths) {
+      const path = this.pathJoin(this.getAndroidHome(), relativePath) + sdkManagerPathSuffix;
+      if (fs.existsSync(path)) {
+        sdkManagerPath = path;
+        break;
+      }
     }
-    if (!fs.existsSync(sdkManagerPath)) {
-      // Android SDK version `6858069` and above doesn't have a `tools` folder anymore.
-      sdkManagerPath = this.pathJoin(this.getAndroidHome(), '/bin/sdkmanager');
-      if (this.process.platform === 'win32') {
-        sdkManagerPath += '.bat';
-      }
-      if (!fs.existsSync(sdkManagerPath)) {
-        throw new Error(`Could not find sdkmanager at: ${sdkManagerPath}`);
-      }
+    if (!sdkManagerPath) {
+      throw new Error(`Could not find sdkmanager at: ${this.getAndroidHome()}`);
     }
 
     this.log.info('Installing Build Tools');
@@ -114,7 +116,7 @@ export class AndroidSdkTools {
    */
   async checkBuildTools(): Promise<boolean> {
     const buildToolsPath =
-        this.pathJoin(this.getAndroidHome(), '/build-tools/', BUILD_TOOLS_VERSION);
+      this.pathJoin(this.getAndroidHome(), '/build-tools/', BUILD_TOOLS_VERSION);
     return fs.existsSync(buildToolsPath);
   }
 
@@ -244,13 +246,17 @@ export class AndroidSdkTools {
    * @param {string} sdkPath the path to the sdk.
    */
   static async validatePath(sdkPath: string): Promise<Result<string, ValidatePathError>> {
+    const cmdlineToolsPath = path.join(sdkPath, 'cmdline-tools');
     const toolsPath = path.join(sdkPath, 'tools');
     const binPath = path.join(sdkPath, 'bin');
 
     // Checks if the path provided is valid. Older versions of the the Android SDK add the
     // initial files inside the `tools` folder. Version `6858069` and above add it directly
     // to the `bin` folder.
-    if (!fs.existsSync(sdkPath) || (!fs.existsSync(toolsPath)) && !fs.existsSync(binPath)) {
+    if (
+      !fs.existsSync(sdkPath) ||
+      (!fs.existsSync(cmdlineToolsPath) && !fs.existsSync(toolsPath)) && !fs.existsSync(binPath)
+    ) {
       return Result.error(
           new ValidatePathError('The provided androidSdk isn\'t correct.', 'PathIsNotCorrect'));
     };

--- a/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
+++ b/packages/core/src/lib/androidSdk/AndroidSdkTools.ts
@@ -84,9 +84,9 @@ export class AndroidSdkTools {
     const sdkManagerPathSuffix = this.process.platform === 'win32' ? '.bat' : '';
     let sdkManagerPath: string | undefined;
     const sdkManagerRelativePaths = [
-      'cmdline-tools/latest/bin/sdkmanager',
-      'tools/bin/sdkmanager',
-      'bin/sdkmanager',
+      'cmdline-tools/latest/bin/sdkmanager', // Latest versions
+      'bin/sdkmanager', // Version 6858069
+      'tools/bin/sdkmanager', // Older versions
     ];
     for (const relativePath of sdkManagerRelativePaths) {
       const path = this.pathJoin(this.getAndroidHome(), relativePath) + sdkManagerPathSuffix;
@@ -250,12 +250,12 @@ export class AndroidSdkTools {
     const toolsPath = path.join(sdkPath, 'tools');
     const binPath = path.join(sdkPath, 'bin');
 
-    // Checks if the path provided is valid. Older versions of the the Android SDK add the
-    // initial files inside the `tools` folder. Version `6858069` and above add it directly
-    // to the `bin` folder.
+    // Checks if the path provided is valid. Older versions of the Android SDK add the
+    // initial files inside the `tools` folder. Version `6858069` add it directly
+    // to the `bin` folder. The latest versions add it to the `cmdline-tools` directory.
     if (
       !fs.existsSync(sdkPath) ||
-      (!fs.existsSync(cmdlineToolsPath) && !fs.existsSync(toolsPath)) && !fs.existsSync(binPath)
+      (!fs.existsSync(cmdlineToolsPath) && !fs.existsSync(binPath) && !fs.existsSync(toolsPath))
     ) {
       return Result.error(
           new ValidatePathError('The provided androidSdk isn\'t correct.', 'PathIsNotCorrect'));

--- a/packages/core/src/lib/jdk/JdkHelper.ts
+++ b/packages/core/src/lib/jdk/JdkHelper.ts
@@ -137,10 +137,12 @@ export class JdkHelper {
     // Concatenates the Java binary path to the existing PATH environment variable.
     let pathEnvironmentKey = 'PATH';
     let pathEnvironment = env['PATH'];
-    if (process.platform === 'win32') {
+    if (this.process.platform === 'win32') {
+      // On Windows, env vars are case-insensitive. Node.js uses the first match in
+      // lexicographic order, so we remove 'PATH' to avoid conflicts with 'Path'.
       delete env['PATH'];
       pathEnvironmentKey = 'Path';
-      pathEnvironment = env['Path'] || pathEnvironment;
+      pathEnvironment = env['Path'] || pathEnvironment || '';
     }
     env[pathEnvironmentKey] = this.getJavaBin() + this.pathSeparator + pathEnvironment;
     return env;

--- a/packages/core/src/lib/jdk/JdkHelper.ts
+++ b/packages/core/src/lib/jdk/JdkHelper.ts
@@ -34,7 +34,6 @@ export class JdkHelper {
   private config: Config;
   private joinPath: JoinPathFunction;
   private pathSeparator: string;
-  private pathEnvironmentKey: string;
 
   /**
    * Constructs a new instance of JdkHelper.
@@ -48,11 +47,9 @@ export class JdkHelper {
     if (process.platform === 'win32') {
       this.joinPath = path.win32.join;
       this.pathSeparator = ';';
-      this.pathEnvironmentKey = 'Path';
     } else {
       this.joinPath = path.posix.join;
       this.pathSeparator = ':';
-      this.pathEnvironmentKey = 'PATH';
     }
   }
 
@@ -138,8 +135,14 @@ export class JdkHelper {
     const env: NodeJS.ProcessEnv = Object.assign({}, this.process.env);
     env['JAVA_HOME'] = this.getJavaHome();
     // Concatenates the Java binary path to the existing PATH environment variable.
-    env[this.pathEnvironmentKey] =
-        this.getJavaBin() + this.pathSeparator + env[this.pathEnvironmentKey];
+    let pathEnvironmentKey = 'PATH';
+    let pathEnvironment = env['PATH'];
+    if (process.platform === 'win32') {
+      delete env['PATH'];
+      pathEnvironmentKey = 'Path';
+      pathEnvironment = env['Path'] || pathEnvironment;
+    }
+    env[pathEnvironmentKey] = this.getJavaBin() + this.pathSeparator + pathEnvironment;
     return env;
   }
 }


### PR DESCRIPTION
This PR improves cross-platform compatibility for Android SDK and JDK path handling.

## Changes

- AndroidSdkTools.ts: Enhanced sdkmanager path detection to support multiple Android SDK versions (cmdline-tools, bin, tools directories)
- JdkHelper.ts: Improved PATH environment variable handling on Windows (case-insensitive env vars support)

